### PR TITLE
[PyTorch][torch.compile] Make quantizers opaque value objects

### DIFF
--- a/build_tools/pytorch.py
+++ b/build_tools/pytorch.py
@@ -77,6 +77,16 @@ def setup_pytorch_extension(
 
     setup_mpi_flags(include_dirs, cxx_flags)
 
+    # Mirror the NCCL EP gate from setup.py / common CMake. When disabled, the
+    # ep.cpp source no-ops at the #ifdef boundary; without the define it would
+    # produce undefined references to nvte_ep_*.
+    if bool(int(os.getenv("NVTE_WITH_NCCL_EP", "1"))):
+        cxx_flags.append("-DNVTE_WITH_NCCL_EP")
+        # PyTorch's symm-mem headers gate the NCCL_HAS_SYMMEM_* feature macros on
+        # USE_NCCL. The EP extension shares the symm-mem NCCL comm with torch, so
+        # it needs those macros visible.
+        cxx_flags.append("-DUSE_NCCL")
+
     library_dirs = []
     libraries = []
     if bool(int(os.getenv("NVTE_ENABLE_NVSHMEM", 0))):

--- a/examples/jax/ep/bench/run_ep_bench.sh
+++ b/examples/jax/ep/bench/run_ep_bench.sh
@@ -47,6 +47,13 @@ NUM_GPUS=$(nvidia-smi -L 2>/dev/null | wc -l)
 if [ "${NUM_GPUS}" -lt 4 ]; then
   echo "EP bench requires >=4 GPUs (found ${NUM_GPUS}); SKIPPING."; exit 0
 fi
+
+# NCCL EP requires active NVLink P2P among ranks on the node.
+if ! nvidia-smi nvlink --status 2>/dev/null | grep -qE 'Link [0-9]+:.*GB/s'; then
+  echo "NVLink not detected on this platform — EP bench requires NVLink; SKIPPING."
+  exit 0
+fi
+
 NUM=4
 COORD="${COORD:-127.0.0.1:23457}"
 TIMEOUT_S="${TIMEOUT_S:-1800}"

--- a/examples/pytorch/ep/bench/ep_bench.py
+++ b/examples/pytorch/ep/bench/ep_bench.py
@@ -1,0 +1,421 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""PyTorch EP perf bench: raw and autograd dispatch/combine on a single EP group.
+
+One process per GPU; launched via run_ep_bench.sh (torchrun).
+
+Stages (each timed in its own loop):
+  - dispatch_raw:        _ep_dispatch_raw (no autograd, no prepare)
+  - ep_dispatch_fwd:     ep_dispatch forward only
+  - ep_dispatch_fwd_bwd: ep_dispatch + backward on 0.5 * ||recv||^2
+  - combine_raw:         _ep_combine_raw (no autograd)
+  - ep_combine_fwd:      ep_combine forward only
+  - ep_combine_fwd_bwd:  ep_combine + backward
+
+ep_prepare runs once outside the timed loops. --kineto DIR dumps a Chrome
+trace plus a per-kernel summary on rank 0.
+"""
+
+import argparse
+import gc
+import os
+import sys
+import time
+from contextlib import nullcontext
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from transformer_engine.pytorch.ep import (
+    EpBuffer,
+    ep_bootstrap,
+    ep_combine,
+    ep_dispatch,
+    ep_finalize,
+    ep_prepare,
+    _ep_combine_raw,
+    _ep_dispatch_raw,
+)
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="TE-PyTorch EP perf bench")
+    p.add_argument("--tokens-per-rank", type=int, default=8192)
+    p.add_argument("--hidden", type=int, default=7168)
+    p.add_argument("--top-k", type=int, default=8)
+    p.add_argument("--num-experts", type=int, default=256)
+    p.add_argument("--warmup", type=int, default=2)
+    p.add_argument("--iters", type=int, default=10)
+    p.add_argument(
+        "--max-num-sms",
+        type=int,
+        default=0,
+        help="Max SMs for dispatch/combine/preprocess kernels (0 = auto).",
+    )
+    p.add_argument(
+        "--kineto",
+        default=None,
+        help="If set, dump a Kineto Chrome trace + per-kernel summary into this dir (rank 0).",
+    )
+    p.add_argument(
+        "--cuda-graph",
+        action="store_true",
+        default=False,
+        help=(
+            "Capture each stage into a CUDA graph and time replay() instead of the eager call. "
+            "Raw + fwd-only stages use torch.cuda.graph; fwd+bwd stages use "
+            "torch.cuda.make_graphed_callables to capture forward and backward together."
+        ),
+    )
+    p.add_argument(
+        "--mode-label",
+        default=None,
+        help="Optional suffix for NVTX range names (e.g. 'fused' / 'unfused').",
+    )
+    p.add_argument(
+        "--caller-provides-dispatch-recv-tokens",
+        action="store_true",
+        default=False,
+        help="Supply recv_tokens to ep_dispatch instead of letting EpBuffer own it.",
+    )
+    p.add_argument(
+        "--caller-provides-grad-expert-out",
+        action="store_true",
+        default=False,
+        help="Supply the combine backward grad buffer to ep_combine.",
+    )
+    return p.parse_args()
+
+
+def _nvtx_funcs():
+    """Return push/pop helpers using torch.cuda.nvtx if available."""
+    try:
+        push = torch.cuda.nvtx.range_push
+        pop = torch.cuda.nvtx.range_pop
+        return push, pop
+    except AttributeError:
+        return lambda _name: None, lambda: None
+
+
+def _device_sm() -> int:
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor
+
+
+def _make_inputs(rank, world_size, T, H, K, E, device):
+    """Round-robin identity routing + uniform top-k weights."""
+    topk_idx = np.empty((T, K), dtype=np.int64)
+    for t in range(T):
+        for k in range(K):
+            topk_idx[t, k] = ((rank * T + t) * K + k) % E
+    rng = np.random.default_rng(seed=42 + rank)
+    tokens_np = (rng.standard_normal((T, H), dtype=np.float32) * 0.5).astype(np.float32)
+    return (
+        torch.from_numpy(topk_idx).to(device),
+        torch.from_numpy(tokens_np).to(device=device, dtype=torch.bfloat16),
+        torch.full((T, K), 1.0 / K, dtype=torch.float32, device=device),
+    )
+
+
+def _time_stage_us(name, fn, iters, nvtx_suffix, push, pop):
+    """Time fn for iters iterations after one untimed warmup; returns mean us."""
+    # Run iters+1 times; drop the first (autotune outlier) and frame NVTX from iter 1.
+    total_ns = 0
+    counted = 0
+    for i in range(iters + 1):
+        if i == 1:
+            push(f"{name}{nvtx_suffix}")
+        torch.cuda.synchronize()
+        t0 = time.perf_counter_ns()
+        fn()
+        torch.cuda.synchronize()
+        dt = time.perf_counter_ns() - t0
+        if i == 0:
+            continue
+        total_ns += dt
+        counted += 1
+    pop()
+    return total_ns / 1e3 / counted
+
+
+def main():
+    args = _parse_args()
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    if _device_sm() < 90:
+        if rank == 0:
+            print(f"[ep_bench] SKIPPED: EP requires SM>=90 (got SM{_device_sm()})")
+        dist.destroy_process_group()
+        return
+    if world_size < 4:
+        if rank == 0:
+            print(f"[ep_bench] SKIPPED: EP requires >=4 ranks (got {world_size})")
+        dist.destroy_process_group()
+        return
+
+    ep_size = world_size
+    E = args.num_experts
+    assert E % ep_size == 0, f"num_experts ({E}) must be divisible by ep_size ({ep_size})"
+    num_local_experts = E // ep_size
+    T = args.tokens_per_rank
+    H = args.hidden
+    K = args.top_k
+    # Conservative cap: every token could land on every local expert.
+    recv_pr = world_size * T * K // 2
+    if rank == 0:
+        print(
+            f"[ep_bench] world={world_size} ep={ep_size} T={T} H={H} K={K} "
+            f"E={E} (local={num_local_experts}) recv_pr={recv_pr}"
+            + (f" mode={args.mode_label}" if args.mode_label else ""),
+            flush=True,
+        )
+
+    ep_group = dist.new_group(ranks=list(range(world_size)), backend="nccl")
+    ep_bootstrap(
+        ep_group,
+        num_experts=E,
+        max_tokens_per_rank=T,
+        recv_capacity_per_rank=recv_pr,
+        hidden_dim=H,
+        max_num_sms=args.max_num_sms,
+    )
+
+    topk_idx, tokens_hbm, topk_w_hbm = _make_inputs(rank, world_size, T, H, K, E, device)
+
+    # Caller-supplied buffers for the autograd ep_dispatch/ep_combine stages
+    # (normal mode -> plain tensors), reused across iters. None when not opted in.
+    caller_recv_tokens = (
+        torch.empty(recv_pr, H, dtype=torch.bfloat16, device=device)
+        if args.caller_provides_dispatch_recv_tokens
+        else None
+    )
+    caller_grad_expert_out = (
+        torch.empty(recv_pr, H, dtype=torch.bfloat16, device=device)
+        if args.caller_provides_grad_expert_out
+        else None
+    )
+
+    buffer = EpBuffer(
+        top_k=K,
+        max_tokens_per_rank=T,
+        recv_capacity_per_rank=recv_pr,
+        hidden_dim=H,
+        num_local_experts=num_local_experts,
+        dispatch_recv_tokens=caller_recv_tokens,
+        combine_grad_expert_out=caller_grad_expert_out,
+    )
+
+    tokens = tokens_hbm
+    topk_w = topk_w_hbm
+    recv_tokens = torch.empty(recv_pr, H, dtype=torch.bfloat16, device=device)
+    recv_w = torch.empty(recv_pr, dtype=torch.float32, device=device)
+
+    # -- Prepare once outside the timed loops ------------------------------
+    ep_prepare(buffer, topk_idx)
+    torch.cuda.synchronize()
+
+    # Pre-dispatch a steady recv_tokens / recv_w so combine stages have valid input.
+    _ep_dispatch_raw(buffer, topk_idx, tokens, topk_w, recv_tokens, recv_w)
+    torch.cuda.synchronize()
+    # fp-equivalent stand-in for an MLP output.
+    expert_out = recv_tokens.clone()
+
+    nvtx_suffix = f"[{args.mode_label}]" if args.mode_label else ""
+    push, pop = _nvtx_funcs()
+
+    # -- Stage closures ----------------------------------------------------
+    # Persistent fwd+bwd inputs (make_graphed_callables needs stable storage).
+    tokens_p = tokens.detach().clone().requires_grad_(True)
+    eo_p = recv_tokens.detach().clone().requires_grad_(True)
+
+    # Stand-in callables; the cuda-graph branch below swaps in graphed versions.
+    fwd_bwd_dispatch_fn = lambda x: ep_dispatch(buffer, x, topk_idx, topk_w)[0]  # noqa: E731
+    fwd_bwd_combine_fn = lambda expert_out: ep_combine(buffer, expert_out)  # noqa: E731
+
+    def _dispatch_raw():
+        _ep_dispatch_raw(buffer, topk_idx, tokens, topk_w, recv_tokens, recv_w)
+
+    def _combine_raw():
+        out_buf = torch.empty(T, H, dtype=torch.bfloat16, device=device)
+        _ep_combine_raw(buffer, expert_out, out_buf)
+
+    def _ep_dispatch_fwd():
+        ep_dispatch(buffer, tokens.detach(), topk_idx, topk_w)
+
+    def _ep_dispatch_fwd_bwd():
+        tokens_p.grad = None
+        r = fwd_bwd_dispatch_fn(tokens_p)
+        (0.5 * (r * r).sum(dtype=torch.float32)).backward()
+
+    def _ep_combine_fwd():
+        ep_combine(buffer, recv_tokens)
+
+    def _ep_combine_fwd_bwd():
+        eo_p.grad = None
+        out = fwd_bwd_combine_fn(eo_p)
+        (0.5 * (out * out).sum(dtype=torch.float32)).backward()
+
+    stages = [
+        ("dispatch_raw", _dispatch_raw, True),
+        ("ep_dispatch_fwd", _ep_dispatch_fwd, True),
+        ("ep_dispatch_fwd_bwd", _ep_dispatch_fwd_bwd, False),
+        ("combine_raw", _combine_raw, True),
+        ("ep_combine_fwd", _ep_combine_fwd, True),
+        ("ep_combine_fwd_bwd", _ep_combine_fwd_bwd, False),
+    ]
+    # Third tuple element: True = direct torch.cuda.graph capture; False = use
+    # make_graphed_callables (autograd-aware) instead.
+
+    # -- Warmup -----------------------------------------------------------
+    for _ in range(args.warmup):
+        for _name, fn, _capt in stages:
+            fn()
+    torch.cuda.synchronize()
+
+    # -- Optional CUDA-graph capture --------------------------------------
+    # Capture each capturable stage on a side stream and time .replay()
+    # instead of the eager call. Outputs allocated inside the
+    # autograd.Function's forward go through the per-capture private pool
+    # so addresses stay stable across replays.
+    captured_runners = {}
+    if args.cuda_graph:
+        # Graph fwd+bwd of the autograd-wrapped ops via make_graphed_callables.
+        class _DispatchMod(torch.nn.Module):
+            def forward(self, x):
+                return ep_dispatch(buffer, x, topk_idx, topk_w)[0]
+
+        class _CombineMod(torch.nn.Module):
+            def forward(self, expert_out):
+                return ep_combine(buffer, expert_out)
+
+        disp_mod = _DispatchMod().cuda()
+        comb_mod = _CombineMod().cuda()
+        g_disp, g_comb = torch.cuda.make_graphed_callables(
+            (disp_mod, comb_mod),
+            ((tokens_p,), (eo_p,)),
+        )
+        fwd_bwd_dispatch_fn = g_disp
+        fwd_bwd_combine_fn = g_comb
+
+        # Direct torch.cuda.graph capture for raw + fwd-only stages.
+        side = torch.cuda.Stream()
+        side.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(side):
+            for name, fn, direct_capturable in stages:
+                if not direct_capturable:
+                    continue
+                fn()  # prime the allocator for stable replay addresses
+                torch.cuda.synchronize()
+                g = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(g):
+                    fn()
+                captured_runners[name] = g
+        torch.cuda.current_stream().wait_stream(side)
+        torch.cuda.synchronize()
+
+    # -- Optional Kineto profiling ----------------------------------------
+    kineto_ctx = nullcontext()
+    if args.kineto and rank == 0:
+        os.makedirs(args.kineto, exist_ok=True)
+        kineto_ctx = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            record_shapes=False,
+            with_stack=False,
+        )
+
+    # -- Timed loops ------------------------------------------------------
+    results = {}
+    with kineto_ctx as prof:
+        for name, fn, _ in stages:
+            runner = fn
+            if name in captured_runners:
+                # Time replay() instead of the eager call.
+                graph = captured_runners[name]
+                runner = graph.replay
+            results[name] = _time_stage_us(name, runner, args.iters, nvtx_suffix, push, pop)
+
+    if rank == 0:
+        label = f" [{args.mode_label}]" if args.mode_label else ""
+        print("", flush=True)
+        print(f"| stage                | mean wall (us){label} |", flush=True)
+        print("|----------------------|---------------:|", flush=True)
+        for name in (
+            "dispatch_raw",
+            "ep_dispatch_fwd",
+            "ep_dispatch_fwd_bwd",
+            "combine_raw",
+            "ep_combine_fwd",
+            "ep_combine_fwd_bwd",
+        ):
+            print(f"| {name:20s} | {results[name]:14.1f} |", flush=True)
+        print(
+            "| (dispatch fwd-raw)   |"
+            f" {results['ep_dispatch_fwd'] - results['dispatch_raw']:14.1f} |",
+            flush=True,
+        )
+        print(
+            "| (dispatch bwd-fwd)   |"
+            f" {results['ep_dispatch_fwd_bwd'] - results['ep_dispatch_fwd']:14.1f} |",
+            flush=True,
+        )
+        print(
+            "| (combine fwd-raw)    |"
+            f" {results['ep_combine_fwd'] - results['combine_raw']:14.1f} |",
+            flush=True,
+        )
+        print(
+            "| (combine bwd-fwd)    |"
+            f" {results['ep_combine_fwd_bwd'] - results['ep_combine_fwd']:14.1f} |",
+            flush=True,
+        )
+        print("", flush=True)
+
+    if args.kineto and rank == 0 and prof is not None:
+        trace_path = os.path.join(args.kineto, "ep_bench_trace.json")
+        prof.export_chrome_trace(trace_path)
+        print(f"[ep_bench] kineto trace: {trace_path}", flush=True)
+        print(
+            prof.key_averages().table(sort_by="cuda_time_total", row_limit=30),
+            flush=True,
+        )
+        kern_csv = os.path.join(args.kineto, "ep_bench_kernels.csv")
+        with open(kern_csv, "w") as f:
+            f.write("name,cuda_time_us,cpu_time_us,count\n")
+            for evt in prof.key_averages():
+                if evt.device_time_total == 0 and evt.cpu_time_total == 0:
+                    continue
+                f.write(f"{evt.key},{evt.device_time_total},{evt.cpu_time_total},{evt.count}\n")
+        print(f"[ep_bench] per-kernel CSV: {kern_csv}", flush=True)
+
+    # Captured CUDA graphs (when --cuda-graph) hold references to NCCL EP
+    # handles and per-pool streams; drop them and sync before ep_finalize,
+    # otherwise the post-finalize dist.barrier can deadlock against pending
+    # graph state.
+    torch.cuda.synchronize()
+    if args.cuda_graph:
+        fwd_bwd_dispatch_fn = None
+        fwd_bwd_combine_fn = None
+        captured_runners.clear()
+        del g_disp, g_comb, disp_mod, comb_mod
+    del tokens_p, eo_p, buffer, recv_tokens, recv_w, tokens, topk_w, expert_out
+    gc.collect()
+    torch.cuda.synchronize()
+    # Release NCCL EP's borrowed comm before torch destroys it.
+    ep_finalize()
+    dist.barrier()
+    dist.destroy_process_group()
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/ep/bench/run_ep_bench.sh
+++ b/examples/pytorch/ep/bench/run_ep_bench.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+#
+# Launcher for examples/pytorch/ep/bench/ep_bench.py.
+# Examples:
+#   bash run_ep_bench.sh                  # plain run, stdout only
+#   bash run_ep_bench.sh --cuda-graph     # capture + replay each stage as a CUDA graph
+#   bash run_ep_bench.sh --kineto         # Chrome trace + per-kernel CSV (rank 0)
+#   bash run_ep_bench.sh --nsys           # nsys profile on rank 0 -> results/pyt_nsys.nsys-rep
+
+set -uo pipefail
+
+NSYS=0; KINETO=0; CGRAPH=0
+for a in "$@"; do
+  case "$a" in
+    --nsys)        NSYS=1 ;;
+    --kineto)      KINETO=1 ;;
+    --cuda-graph)  CGRAPH=1 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+if [ "${NSYS}" -eq 1 ] && [ "${KINETO}" -eq 1 ]; then
+  echo "--nsys and --kineto both attach CUPTI; pick one." >&2; exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TE_REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+RESULTS="${SCRIPT_DIR}/results"
+mkdir -p "${RESULTS}"
+export PYTHONPATH="${TE_REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+DETECTED_GPUS=$(nvidia-smi -L 2>/dev/null | wc -l)
+NUM_GPUS="${NUM_GPUS:-${DETECTED_GPUS}}"
+if [ "${NUM_GPUS}" -lt 4 ]; then
+  echo "EP bench requires >=4 GPUs (found ${NUM_GPUS}); SKIPPING."; exit 0
+fi
+if [ "${NUM_GPUS}" -gt 8 ]; then NUM_GPUS=8; fi
+
+: "${TIMEOUT_S:=1800}"
+: "${NCCL_EP_JIT_CACHE_DIR:=${TMPDIR:-/tmp}/nccl_ep_jit_cache_$(id -u)}"
+export NCCL_EP_JIT_CACHE_DIR
+mkdir -p "${NCCL_EP_JIT_CACHE_DIR}"
+
+EXTRA_ARGS=()
+TAG="pyt"
+[ "${CGRAPH}" -eq 1 ] && EXTRA_ARGS+=(--cuda-graph) && TAG="${TAG}_cg"
+if [ "${KINETO}" -eq 1 ]; then
+  EXTRA_ARGS+=(--kineto "${RESULTS}/kineto_${TAG}")
+fi
+
+EP_BENCH_EXTRA_FLAGS="${EP_BENCH_EXTRA_FLAGS:-}"
+LAUNCH=(torchrun --standalone --nnodes=1 --nproc-per-node="${NUM_GPUS}"
+        "${SCRIPT_DIR}/ep_bench.py" "${EXTRA_ARGS[@]}" ${EP_BENCH_EXTRA_FLAGS})
+
+if [ "${NSYS}" -eq 1 ]; then
+  NSYS_CMD=(nsys profile
+            --output "${RESULTS}/pyt_${TAG}_nsys"
+            --force-overwrite=true
+            --trace=cuda,nvtx
+            --gpu-metrics-devices=none
+            --cuda-um-cpu-page-faults=false
+            --cuda-um-gpu-page-faults=false)
+  echo "[run_ep_bench] launching with nsys (results/${TAG}_nsys.nsys-rep)"
+  timeout --foreground --signal=TERM "${TIMEOUT_S}" "${NSYS_CMD[@]}" "${LAUNCH[@]}"
+  RC=$?
+else
+  timeout --foreground --signal=TERM "${TIMEOUT_S}" "${LAUNCH[@]}"
+  RC=$?
+fi
+exit $RC

--- a/examples/pytorch/ep/bench/run_nccl_ep_bench.sh
+++ b/examples/pytorch/ep/bench/run_nccl_ep_bench.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+#
+# Launcher for the native NCCL EP ``ep_bench`` (baseline for PyTorch comparison).
+# Usage:
+#   bash run_nccl_ep_bench.sh           # plain run, stdout only
+#   bash run_nccl_ep_bench.sh --nsys    # nsys → results/nccl_ep_nsys.nsys-rep
+
+set -uo pipefail
+
+NSYS=0
+for a in "$@"; do
+  case "$a" in
+    --nsys) NSYS=1 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TE_REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+RESULTS="${SCRIPT_DIR}/results"
+mkdir -p "${RESULTS}"
+
+BIN="${TE_REPO_ROOT}/3rdparty/nccl/build/test/nccl_ep/ep_bench"
+LIB="${TE_REPO_ROOT}/3rdparty/nccl/build/lib"
+[ -x "${BIN}" ] || { echo "ep_bench not built at ${BIN}" >&2; exit 2; }
+
+NUM_GPUS=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ "${NUM_GPUS}" -lt 4 ]; then
+  echo "NCCL EP bench requires >=4 GPUs (found ${NUM_GPUS}); SKIPPING."; exit 0
+fi
+if [ "${NUM_GPUS}" -gt 8 ]; then NUM_GPUS=8; fi
+
+if [ "${NSYS}" -eq 1 ]; then
+  ITERS=10
+else
+  ITERS=50
+fi
+ARGS=(--algorithm ht --layout em --tokens 2048 --hidden 7168 --top-k 8
+      --experts 256 --warmup 5 --iters "${ITERS}")
+[ "${NSYS}" -eq 1 ] && ARGS+=(--profile)  # enables NVTX ranges + cudaProfilerStart/Stop
+
+CMD=(/usr/local/mpi/bin/mpirun --allow-run-as-root --oversubscribe -np "${NUM_GPUS}"
+     -x LD_LIBRARY_PATH="${LIB}:${LD_LIBRARY_PATH:-}"
+     "${BIN}" "${ARGS[@]}")
+
+if [ "${NSYS}" -eq 1 ]; then
+  CMD=(nsys profile
+       --output "${RESULTS}/nccl_ep_nsys"
+       --force-overwrite=true
+       --capture-range=cudaProfilerApi
+       --capture-range-end=stop
+       --trace=cuda,nvtx,osrt
+       "${CMD[@]}")
+fi
+
+[ "${NSYS}" -eq 1 ] && SUFFIX="_nsys" || SUFFIX=""
+LOG="${RESULTS}/stdout_nccl_ep${SUFFIX}.txt"
+"${CMD[@]}" 2>&1 | tee "${LOG}"
+echo "Done. Log: ${LOG}"

--- a/examples/pytorch/ep/ep_moe.py
+++ b/examples/pytorch/ep/ep_moe.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""End-to-end MoE example: dispatch -> batched expert linear -> combine, fwd + bwd.
+
+One process per GPU; launched via run_test_ep.sh (torchrun).
+"""
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from transformer_engine.pytorch.ep import (
+    EpBuffer,
+    ep_bootstrap,
+    ep_combine,
+    ep_dispatch,
+    ep_finalize,
+)
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(description="TE-PyTorch EP MoE example (fwd + bwd)")
+    p.add_argument("--num-tokens", type=int, default=8, help="Per-rank token count.")
+    p.add_argument("--top-k", type=int, default=2)
+    p.add_argument("--hidden", type=int, default=32)
+    p.add_argument("--hidden-out", type=int, default=32)
+    p.add_argument("--num-experts", type=int, default=None)
+    p.add_argument("--check", action="store_true", default=True)
+    p.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Time fwd over HBM buffers.",
+    )
+    p.add_argument("--benchmark-iters", type=int, default=20)
+    p.add_argument("--benchmark-warmup", type=int, default=5)
+    p.add_argument(
+        "--caller-provides-dispatch-recv-tokens",
+        action="store_true",
+        default=False,
+        help="Supply recv_tokens to ep_dispatch instead of letting EpBuffer own it.",
+    )
+    p.add_argument(
+        "--caller-provides-grad-expert-out",
+        action="store_true",
+        default=False,
+        help="Supply the combine backward grad buffer to ep_combine.",
+    )
+    return p.parse_args()
+
+
+def _make_routing(rank, T, K, E, num_local_experts):
+    """Deterministic routing: topk_idx[t, k] = (rank*NLE + t*K + k) % E."""
+    topk_idx = np.empty((T, K), dtype=np.int64)
+    for t in range(T):
+        for k in range(K):
+            topk_idx[t, k] = (rank * num_local_experts + t * K + k) % E
+    return topk_idx
+
+
+def _batched_expert_linear(recv_tokens, kernels, num_local_experts):
+    """Per-expert linear via bmm; ``recv_pr // num_local_experts`` slots per expert."""
+    recv_pr, _H = recv_tokens.shape
+    H_out = kernels.shape[-1]
+    slots_per_expert = recv_pr // num_local_experts
+    grouped = recv_tokens.view(num_local_experts, slots_per_expert, recv_tokens.shape[-1])
+    out = torch.bmm(grouped, kernels.to(grouped.dtype))
+    return out.view(recv_pr, H_out)
+
+
+def _reference_moe(tokens, topk_idx, topk_w, kernels):
+    T, K = topk_idx.shape
+    H_out = kernels.shape[-1]
+    out = np.zeros((T, H_out), dtype=np.float32)
+    for t in range(T):
+        tok = tokens[t].astype(np.float32)
+        for k in range(K):
+            e = int(topk_idx[t, k])
+            out[t] += float(topk_w[t, k]) * (tok @ kernels[e].astype(np.float32))
+    return out
+
+
+def _reference_grad(tokens, topk_idx, topk_w, kernels):
+    T, K = topk_idx.shape
+    H = tokens.shape[-1]
+    ref_out = _reference_moe(tokens, topk_idx, topk_w, kernels)
+    grad = np.zeros((T, H), dtype=np.float32)
+    for t in range(T):
+        mixed = np.zeros_like(kernels[0])
+        for k in range(K):
+            mixed = mixed + float(topk_w[t, k]) * kernels[int(topk_idx[t, k])]
+        grad[t] = ref_out[t] @ mixed.T
+    return ref_out, grad
+
+
+def main():
+    args = _parse_args()
+
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 90:
+        if rank == 0:
+            print(f"[ep_moe] SKIPPED: EP requires SM>=90 (got SM{major}{minor})")
+        dist.destroy_process_group()
+        return
+
+    if world_size < 4:
+        if rank == 0:
+            print(f"[ep_moe] SKIPPED: EP requires >= 4 ranks (got {world_size})")
+        dist.destroy_process_group()
+        return
+
+    ep_size = world_size
+    num_experts = args.num_experts if args.num_experts is not None else world_size
+    assert num_experts % ep_size == 0
+    num_local_experts = num_experts // ep_size
+    T = args.num_tokens
+    recv_pr = ep_size * T * args.top_k
+
+    ep_group = dist.new_group(ranks=list(range(world_size)), backend="nccl")
+    ep_bootstrap(
+        ep_group,
+        num_experts=num_experts,
+        max_tokens_per_rank=T,
+        recv_capacity_per_rank=recv_pr,
+        hidden_dim=args.hidden,
+    )
+    try:
+        _run_layer(
+            args, rank, world_size, ep_size, num_experts, num_local_experts, T, recv_pr, device
+        )
+    finally:
+        ep_finalize()
+        dist.destroy_process_group()
+
+
+def _run_layer(args, rank, world_size, ep_size, num_experts, num_local_experts, T, recv_pr, device):
+    rng = np.random.default_rng(seed=42 + rank)
+    tokens_np = (rng.standard_normal((T, args.hidden), dtype=np.float32) * 0.5).astype(np.float32)
+    topk_idx_np = _make_routing(rank, T, args.top_k, num_experts, num_local_experts)
+    w_np = np.full((T, args.top_k), 1.0 / args.top_k, dtype=np.float32)
+    # Same seed across ranks -> identical kernel array everywhere.
+    kr = np.random.default_rng(seed=42)
+    kernels_np = (
+        kr.standard_normal((num_experts, args.hidden, args.hidden_out), dtype=np.float32)
+        * (1.0 / np.sqrt(args.hidden))
+    ).astype(np.float32)
+
+    tokens = (
+        torch.from_numpy(tokens_np).to(device=device, dtype=torch.bfloat16).requires_grad_(True)
+    )
+    topk_idx = torch.from_numpy(topk_idx_np).to(device)
+    topk_w = torch.from_numpy(w_np).to(device)
+    kernels_local = torch.from_numpy(
+        kernels_np[rank * num_local_experts : (rank + 1) * num_local_experts]
+    ).to(device=device, dtype=torch.bfloat16)
+
+    # Caller-supplied buffers (normal mode -> plain tensors), reused across iters.
+    recv_tokens = (
+        torch.empty(recv_pr, args.hidden, dtype=torch.bfloat16, device=device)
+        if args.caller_provides_dispatch_recv_tokens
+        else None
+    )
+    grad_expert_out = (
+        torch.empty(recv_pr, args.hidden, dtype=torch.bfloat16, device=device)
+        if args.caller_provides_grad_expert_out
+        else None
+    )
+
+    buffer = EpBuffer(
+        top_k=args.top_k,
+        max_tokens_per_rank=T,
+        recv_capacity_per_rank=recv_pr,
+        hidden_dim=args.hidden,
+        num_local_experts=num_local_experts,
+        dispatch_recv_tokens=recv_tokens,
+        combine_grad_expert_out=grad_expert_out,
+    )
+
+    recv_t, recv_w_out, _tc = ep_dispatch(buffer, tokens, topk_idx, topk_w)
+    expert_out = _batched_expert_linear(recv_t, kernels_local, num_local_experts)
+    # Apply per-slot topk weighting before combine.
+    expert_out = expert_out * recv_w_out.unsqueeze(-1).to(expert_out.dtype)
+    out = ep_combine(buffer, expert_out)
+
+    loss = 0.5 * (out.float() ** 2).sum()
+    loss.backward()
+    torch.cuda.synchronize()
+
+    if rank == 0:
+        print(
+            f"[ep_moe] loss={loss.item():.4f} grad_tokens.shape={tuple(tokens.grad.shape)} "
+            f"ep={ep_size} num_experts={num_experts} recv_pr={recv_pr}"
+        )
+
+    if args.benchmark:
+        # Time dispatch + expert + combine over HBM buffers.
+        import time
+
+        torch.cuda.synchronize()
+        dist.barrier()
+        for _ in range(args.benchmark_warmup):
+            rt, rw, _tc = ep_dispatch(buffer, tokens.detach(), topk_idx, topk_w)
+            expert_out = _batched_expert_linear(rt, kernels_local, num_local_experts)
+            expert_out = expert_out * rw.unsqueeze(-1).to(expert_out.dtype)
+            ep_combine(buffer, expert_out)
+        torch.cuda.synchronize()
+        dist.barrier()
+        t0 = time.perf_counter()
+        for _ in range(args.benchmark_iters):
+            rt, rw, _tc = ep_dispatch(buffer, tokens.detach(), topk_idx, topk_w)
+            expert_out = _batched_expert_linear(rt, kernels_local, num_local_experts)
+            expert_out = expert_out * rw.unsqueeze(-1).to(expert_out.dtype)
+            ep_combine(buffer, expert_out)
+        torch.cuda.synchronize()
+        dt_ms = (time.perf_counter() - t0) * 1000.0 / args.benchmark_iters
+        if rank == 0:
+            print(f"[ep_moe --benchmark] HBM: {dt_ms:.3f} ms/iter (iters={args.benchmark_iters})")
+
+    if args.check:
+        # All-gather inputs/outputs/grads for a global reference comparison.
+        global_tokens = [torch.empty_like(tokens) for _ in range(world_size)]
+        global_topk_idx = [torch.empty_like(topk_idx) for _ in range(world_size)]
+        global_topk_w = [torch.empty_like(topk_w) for _ in range(world_size)]
+        global_out = [torch.empty_like(out) for _ in range(world_size)]
+        global_grad = [torch.empty_like(tokens.grad) for _ in range(world_size)]
+        dist.all_gather(global_tokens, tokens.detach())
+        dist.all_gather(global_topk_idx, topk_idx)
+        dist.all_gather(global_topk_w, topk_w)
+        dist.all_gather(global_out, out.detach())
+        dist.all_gather(global_grad, tokens.grad)
+        if rank == 0:
+            all_tokens = torch.cat(global_tokens).float().cpu().numpy()
+            all_idx = torch.cat(global_topk_idx).cpu().numpy()
+            all_w = torch.cat(global_topk_w).cpu().numpy()
+            all_out = torch.cat(global_out).float().cpu().numpy()
+            all_grad = torch.cat(global_grad).float().cpu().numpy()
+            ref_out, ref_grad = _reference_grad(all_tokens, all_idx, all_w, kernels_np)
+            np.testing.assert_allclose(all_out, ref_out, rtol=5e-2, atol=5e-2)
+            np.testing.assert_allclose(all_grad, ref_grad, rtol=5e-2, atol=5e-2)
+            print(f"[ep_moe] --check PASSED (ref_out.sum()={float(ref_out.sum()):.4f})")
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/examples/pytorch/ep/run_test_ep.sh
+++ b/examples/pytorch/ep/run_test_ep.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+set -uo pipefail
+
+DETECTED_GPUS=$(nvidia-smi -L 2>/dev/null | wc -l)
+NUM_GPUS="${NUM_GPUS:-${DETECTED_GPUS}}"
+if [ "${NUM_GPUS}" -lt 4 ]; then
+  echo "EP requires >= 4 GPUs (found ${NUM_GPUS}); SKIPPING."
+  exit 0
+fi
+if [ "${NUM_GPUS}" -gt 8 ]; then NUM_GPUS=8; fi
+
+: ${TE_PATH:=/opt/transformerengine}
+: ${TEST_TIMEOUT_S:=120}
+
+SCRIPT="${TE_PATH}/examples/pytorch/ep/ep_moe.py"
+export PYTHONPATH="${TE_PATH}${PYTHONPATH:+:${PYTHONPATH}}"
+
+# Stage JIT cubins on tmpfs for fast iteration.
+: ${NCCL_EP_JIT_CACHE_DIR:="${TMPDIR:-/tmp}/nccl_ep_jit_cache_$(id -u)"}
+export NCCL_EP_JIT_CACHE_DIR
+mkdir -p "$NCCL_EP_JIT_CACHE_DIR"
+
+echo "*** Executing ep_moe.py across ${NUM_GPUS} GPUs (timeout=${TEST_TIMEOUT_S}s) ***"
+timeout --foreground --signal=KILL "${TEST_TIMEOUT_S}" \
+  torchrun --standalone --nnodes=1 --nproc-per-node="${NUM_GPUS}" \
+  "${SCRIPT}" --check 2>&1 | tee stdout_ep_moe.txt
+RC=${PIPESTATUS[0]}
+
+RET=0
+if [ "${RC}" -ne 0 ]; then RET=1; fi
+if grep -qE "(^|]:)FAILED|(^|]:)Traceback" stdout_ep_moe.txt; then RET=1; fi
+rm -f stdout_ep_moe.txt
+exit $RET

--- a/qa/L1_pytorch_distributed_unittest/test.sh
+++ b/qa/L1_pytorch_distributed_unittest/test.sh
@@ -50,6 +50,7 @@ python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_fusible_ops_with_use
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_cp_utils.xml $TE_PATH/tests/pytorch/attention/test_cp_utils.py || test_fail "test_cp_utils.py"
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_cast_master_weights_to_fp8.xml $TE_PATH/tests/pytorch/distributed/test_cast_master_weights_to_fp8.py || test_fail "test_cast_master_weights_to_fp8.py"
 python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_newton_schulz.xml $TE_PATH/tests/pytorch/distributed/test_newton_schulz.py || test_fail "test_newton_schulz.py"
+python3 -m pytest -v -s --junitxml=$XML_LOG_DIR/pytest_test_ep.xml $TE_PATH/tests/pytorch/distributed/test_ep.py || test_fail "test_ep.py"
 
 
 # debug tests

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,12 @@ def setup_requirements() -> Tuple[List[str], List[str]]:
 
 
 def _discover_nccl_home() -> str:
-    """Resolve NCCL_HOME: honor env var, else probe well-known prefixes, else ldconfig."""
+    """Resolve NCCL_HOME, preferring the NCCL the dynamic loader resolves at runtime.
+
+    Probes in order: NCCL_HOME env var, ldconfig cache, well-known prefixes, then a
+    pip-installed nvidia-nccl-cu* wheel. To test a non-default NCCL (e.g. a wheel), set
+    NCCL_HOME and ensure the runtime loader resolves the same lib (e.g. LD_LIBRARY_PATH).
+    """
     env_home = os.environ.get("NCCL_HOME")
     if env_home:
         if (Path(env_home) / "include" / "nccl.h").exists():
@@ -152,28 +157,11 @@ def _discover_nccl_home() -> str:
     # Include Debian/Ubuntu multiarch subdirs (e.g. lib/aarch64-linux-gnu).
     lib_subdirs = ("lib", "lib64", "lib/aarch64-linux-gnu", "lib/x86_64-linux-gnu")
 
-    # pip-installed NCCL (nvidia-nccl-cu* wheel) lives under nvidia/nccl in
-    # site-packages and has no top-level include/lib layout.
-    try:
-        import importlib.util
-
-        spec = importlib.util.find_spec("nvidia.nccl")
-        if spec is not None and spec.submodule_search_locations:
-            pip_root = Path(next(iter(spec.submodule_search_locations)))
-            if (pip_root / "include" / "nccl.h").exists() and any(
-                (pip_root / sub / name).exists() for sub in lib_subdirs for name in lib_names
-            ):
-                return str(pip_root)
-    except (ImportError, ValueError):
-        pass
-
-    for cand in ("/opt/nvidia/nccl", "/usr/local/nccl", "/usr"):
-        p = Path(cand)
-        if (p / "include" / "nccl.h").exists() and any(
-            (p / sub / name).exists() for sub in lib_subdirs for name in lib_names
-        ):
-            return str(p)
-
+    # Prefer the NCCL the dynamic loader will actually resolve at runtime so the
+    # EP build links against the same libnccl that gets loaded. libtransformer_engine
+    # carries no NCCL RUNPATH, so the loader uses ldconfig/system paths; building
+    # against a different NCCL (e.g. a pip wheel) causes ABI mismatches. ldconfig is
+    # the ground truth for runtime resolution, so consult it before well-known prefixes.
     try:
         out = subprocess.check_output(["ldconfig", "-p"], stderr=subprocess.DEVNULL).decode()
         for line in out.splitlines():
@@ -185,6 +173,28 @@ def _discover_nccl_home() -> str:
                     if (root / "include" / "nccl.h").exists():
                         return str(root)
     except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    for cand in ("/opt/nvidia/nccl", "/usr/local/nccl", "/usr"):
+        p = Path(cand)
+        if (p / "include" / "nccl.h").exists() and any(
+            (p / sub / name).exists() for sub in lib_subdirs for name in lib_names
+        ):
+            return str(p)
+
+    # Fall back to a pip-installed NCCL (nvidia-nccl-cu* wheel) under nvidia/nccl
+    # in site-packages, used only when no system NCCL is present.
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("nvidia.nccl")
+        if spec is not None and spec.submodule_search_locations:
+            pip_root = Path(next(iter(spec.submodule_search_locations)))
+            if (pip_root / "include" / "nccl.h").exists() and any(
+                (pip_root / sub / name).exists() for sub in lib_subdirs for name in lib_names
+            ):
+                return str(pip_root)
+    except (ImportError, ValueError):
         pass
 
     raise RuntimeError(

--- a/tests/cpp_distributed/run_test_ep.sh
+++ b/tests/cpp_distributed/run_test_ep.sh
@@ -35,6 +35,12 @@ if (( MIN_SM > 0 && MIN_SM < 90 )); then
     exit 0
 fi
 
+# NCCL EP requires active NVLink P2P among ranks on the node.
+if ! nvidia-smi nvlink --status 2>/dev/null | grep -qE 'Link [0-9]+:.*GB/s'; then
+    echo "NVLink not detected on this platform; SKIPPING."
+    exit 0
+fi
+
 TEST_BIN="${BUILD_DIR}/test_ep"
 if [[ ! -x "${TEST_BIN}" ]]; then
     echo "ERROR: binary not found: ${TEST_BIN}"

--- a/tests/cpp_distributed/test_ep.cu
+++ b/tests/cpp_distributed/test_ep.cu
@@ -60,7 +60,7 @@ static std::vector<T> generate_tokens(int rank, int num_tokens, int hidden_dim) 
   return v;
 }
 
-static std::vector<int32_t> expected_token_counts(
+static std::vector<int32_t> expected_recv_tokens_per_expert(
     int recv_rank, int num_processes, int num_tokens, int top_k,
     int num_experts, int num_local_experts) {
   int base = recv_rank * num_local_experts;
@@ -128,7 +128,7 @@ struct EPBuffers {
   DevBuf<int64_t>     topk_idx;
   DevBuf<float>       topk_weights;
   DevBuf<T>           tokens;
-  DevBuf<int32_t>     token_counts;
+  DevBuf<int32_t>     recv_tokens_per_expert;
   DevBuf<uint8_t>     handle_mem;
   DevBuf<T>           recv_tokens;
   DevBuf<float>       recv_topk_weights;
@@ -144,22 +144,26 @@ struct EPBuffers {
   size_t recv_capacity   = 0;
   int    top_k_          = 0;
   size_t alignment_      = 0;
+  NVTEEpLayerConfig layer_cfg_{};
 
   void alloc(int num_tokens, int top_k, int hidden_dim, int num_local_experts,
              int ep_size, int max_tokens_per_rank, size_t alignment = 0) {
     top_k_ = top_k;
     alignment_ = alignment;
+    layer_cfg_ = NVTE_EP_LAYER_CONFIG_INIT;
+    layer_cfg_.top_k = top_k;
+    layer_cfg_.dispatch_output_per_expert_alignment = alignment;
     recv_capacity = static_cast<size_t>(ep_size) * max_tokens_per_rank * 2;
 
     topk_idx.alloc(num_tokens * top_k);
     topk_weights.alloc(num_tokens * top_k);
     tokens.alloc(num_tokens * hidden_dim);
-    token_counts.alloc(num_local_experts);
+    recv_tokens_per_expert.alloc(num_local_experts);
     recv_tokens.alloc(recv_capacity * hidden_dim);
     recv_topk_weights.alloc(recv_capacity);
     result.alloc(num_tokens * hidden_dim);
 
-    handle_mem_size = nvte_ep_handle_mem_size(NVTEEpLayerConfig{top_k, alignment});
+    handle_mem_size = nvte_ep_handle_mem_size(&layer_cfg_);
     handle_mem.alloc(handle_mem_size);
 
     grad_result.alloc(num_tokens * hidden_dim);
@@ -174,25 +178,29 @@ struct EPBuffers {
 // expects.
 template <typename T = nv_bfloat16>
 struct EPTensors {
-  TensorWrapper topk_idx, topk_weights, token_counts, handle_mem, tokens;
+  TensorWrapper topk_idx, topk_weights, recv_tokens_per_expert, handle_mem, tokens;
   TensorWrapper recv_tokens, recv_topk_weights, result;
   TensorWrapper grad_result, grad_expert, grad_tokens;
   TensorWrapper g_recv_topk_weights, grad_topk_weights;
 
   int    top_k_     = 0;
   size_t alignment_ = 0;
+  NVTEEpLayerConfig layer_cfg_{};
 
   EPTensors(EPBuffers<T>& b, int num_tokens, int top_k, int hidden_dim,
             int num_local_experts) {
     top_k_ = top_k;
     alignment_ = b.alignment_;
+    layer_cfg_ = NVTE_EP_LAYER_CONFIG_INIT;
+    layer_cfg_.top_k = top_k;
+    layer_cfg_.dispatch_output_per_expert_alignment = b.alignment_;
     constexpr DType kTokDType = test::TypeInfo<T>::dtype;
     using Shape = std::vector<size_t>;
     topk_idx          = TensorWrapper(b.topk_idx.get(),
                             Shape{(size_t)num_tokens, (size_t)top_k}, DType::kInt64);
     topk_weights      = TensorWrapper(b.topk_weights.get(),
                             Shape{(size_t)num_tokens, (size_t)top_k}, DType::kFloat32);
-    token_counts      = TensorWrapper(b.token_counts.get(),
+    recv_tokens_per_expert      = TensorWrapper(b.recv_tokens_per_expert.get(),
                             Shape{(size_t)num_local_experts}, DType::kInt32);
     handle_mem        = TensorWrapper(b.handle_mem.get(),
                             Shape{b.handle_mem_size}, DType::kByte);
@@ -259,7 +267,7 @@ class EpOpTestBase : public ::testing::Test {
   template <typename T = nv_bfloat16>
   int read_total_recv(const EPBuffers<T>& buf) const {
     std::vector<int32_t> cnt(num_local_experts_);
-    NVTE_CHECK_CUDA(cudaMemcpy(cnt.data(), buf.token_counts.get(),
+    NVTE_CHECK_CUDA(cudaMemcpy(cnt.data(), buf.recv_tokens_per_expert.get(),
                               num_local_experts_ * sizeof(int32_t), cudaMemcpyDeviceToHost));
     int total = 0;
     for (int c : cnt) total += c;
@@ -300,7 +308,7 @@ TYPED_TEST(EPDispatchTest, PrepareAndDispatch) {
   cudaStream_t stream;
   NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.token_counts.data(), NVTEEpLayerConfig{t.top_k_, t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.recv_tokens_per_expert.data(), nullptr, &t.layer_cfg_, stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), t.topk_idx.data(),
                                    t.tokens.data(), NVTECommWindow{}, t.topk_weights.data(),
                                    NVTECommWindow{}, t.recv_tokens.data(), NVTECommWindow{},
@@ -309,9 +317,9 @@ TYPED_TEST(EPDispatchTest, PrepareAndDispatch) {
 
   // 1. Per-expert counts.
   std::vector<int32_t> got_counts(num_local_experts_);
-  NVTE_CHECK_CUDA(cudaMemcpy(got_counts.data(), buf.token_counts.get(),
+  NVTE_CHECK_CUDA(cudaMemcpy(got_counts.data(), buf.recv_tokens_per_expert.get(),
                         num_local_experts_ * sizeof(int32_t), cudaMemcpyDeviceToHost));
-  auto exp_counts = expected_token_counts(g_process_id, g_num_processes, num_tokens_, top_k_,
+  auto exp_counts = expected_recv_tokens_per_expert(g_process_id, g_num_processes, num_tokens_, top_k_,
                                           num_experts_, num_local_experts_);
   int total_recv = 0;
   for (int i = 0; i < num_local_experts_; ++i) {
@@ -379,7 +387,7 @@ TYPED_TEST(EPCombineTest, Combine) {
   cudaStream_t stream;
   NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.token_counts.data(), NVTEEpLayerConfig{t.top_k_, t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.recv_tokens_per_expert.data(), nullptr, &t.layer_cfg_, stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), t.topk_idx.data(),
                                    t.tokens.data(), NVTECommWindow{}, t.topk_weights.data(),
                                    NVTECommWindow{}, t.recv_tokens.data(), NVTECommWindow{},
@@ -426,7 +434,7 @@ TYPED_TEST(EPCombineBwdTest, CombineBwdCheck) {
   cudaStream_t stream;
   NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.token_counts.data(), NVTEEpLayerConfig{t.top_k_, t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.recv_tokens_per_expert.data(), nullptr, &t.layer_cfg_, stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), t.topk_idx.data(),
                                    t.tokens.data(), NVTECommWindow{}, t.topk_weights.data(),
                                    NVTECommWindow{}, t.recv_tokens.data(), NVTECommWindow{},
@@ -447,7 +455,7 @@ TYPED_TEST(EPCombineBwdTest, CombineBwdCheck) {
   int total_recv = this->template read_total_recv<Tok>(buf);
 
   std::vector<int32_t> cnt(num_local_experts_);
-  NVTE_CHECK_CUDA(cudaMemcpy(cnt.data(), buf.token_counts.get(),
+  NVTE_CHECK_CUDA(cudaMemcpy(cnt.data(), buf.recv_tokens_per_expert.get(),
                         num_local_experts_ * sizeof(int32_t), cudaMemcpyDeviceToHost));
   std::vector<Tok> h_ge(buf.recv_capacity * hidden_dim_);
   NVTE_CHECK_CUDA(cudaMemcpy(h_ge.data(), buf.grad_expert.get(),
@@ -495,7 +503,7 @@ TYPED_TEST(EPDispatchBwdTest, DispatchBwdCheck) {
   cudaStream_t stream;
   NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.token_counts.data(), NVTEEpLayerConfig{t.top_k_, t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.recv_tokens_per_expert.data(), nullptr, &t.layer_cfg_, stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), t.topk_idx.data(),
                                    t.tokens.data(), NVTECommWindow{}, t.topk_weights.data(),
                                    NVTECommWindow{}, t.recv_tokens.data(), NVTECommWindow{},
@@ -563,7 +571,7 @@ TYPED_TEST(EPDispatchBwdGradWeightsTest, RoundTrip) {
   cudaStream_t stream;
   NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.token_counts.data(), NVTEEpLayerConfig{t.top_k_, t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.recv_tokens_per_expert.data(), nullptr, &t.layer_cfg_, stream));
   NVTE_CHECK_CUDA(cudaMemsetAsync(buf.recv_topk_weights.get(), 0,
                              buf.recv_topk_weights.bytes(), stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), t.topk_idx.data(),
@@ -634,7 +642,7 @@ class EPPipelineTest : public EpOpTestBase, public ::testing::WithParamInterface
     cudaStream_t stream;
     NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-    ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.token_counts.data(), NVTEEpLayerConfig{t.top_k_, t.alignment_}, stream));
+    ASSERT_NO_THROW(nvte_ep_prepare(t.handle_mem.data(), t.topk_idx.data(), t.recv_tokens_per_expert.data(), nullptr, &t.layer_cfg_, stream));
     ASSERT_NO_THROW(nvte_ep_dispatch(t.handle_mem.data(), t.topk_idx.data(),
                                      t.tokens.data(), NVTECommWindow{}, t.topk_weights.data(),
                                      NVTECommWindow{}, t.recv_tokens.data(), NVTECommWindow{},
@@ -759,7 +767,7 @@ TYPED_TEST(EPZeroCopyTest, IdentityAllSymm) {
   cudaStream_t stream;
   NVTE_CHECK_CUDA(cudaStreamCreate(&stream));
 
-  ASSERT_NO_THROW(nvte_ep_prepare(ref_t.handle_mem.data(), ref_t.topk_idx.data(), ref_t.token_counts.data(), NVTEEpLayerConfig{ref_t.top_k_, ref_t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(ref_t.handle_mem.data(), ref_t.topk_idx.data(), ref_t.recv_tokens_per_expert.data(), nullptr, &ref_t.layer_cfg_, stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(ref_t.handle_mem.data(), ref_t.topk_idx.data(),
                                    ref_t.tokens.data(), NVTECommWindow{}, ref_t.topk_weights.data(),
                                    NVTECommWindow{}, ref_t.recv_tokens.data(), NVTECommWindow{},
@@ -800,7 +808,7 @@ TYPED_TEST(EPZeroCopyTest, IdentityAllSymm) {
   sym_t.recv_tokens = TensorWrapper(sym_recv.ptr,
                           std::vector<size_t>{sym_buf.recv_capacity, (size_t)hidden_dim_}, kTokDType);
 
-  ASSERT_NO_THROW(nvte_ep_prepare(sym_t.handle_mem.data(), sym_t.topk_idx.data(), sym_t.token_counts.data(), NVTEEpLayerConfig{sym_t.top_k_, sym_t.alignment_}, stream));
+  ASSERT_NO_THROW(nvte_ep_prepare(sym_t.handle_mem.data(), sym_t.topk_idx.data(), sym_t.recv_tokens_per_expert.data(), nullptr, &sym_t.layer_cfg_, stream));
   ASSERT_NO_THROW(nvte_ep_dispatch(sym_t.handle_mem.data(), sym_t.topk_idx.data(),
                                    sym_t.tokens.data(), symm_window(sym_tokens),
                                    sym_t.topk_weights.data(), NVTECommWindow{},

--- a/tests/cpp_distributed/test_ep_common.h
+++ b/tests/cpp_distributed/test_ep_common.h
@@ -146,7 +146,7 @@ static bool ep_bootstrap(int argc, char* argv[]) {
   ncclUniqueId uid{};
   exchange_unique_id(&uid);
 
-  NVTEEpGroupConfig group_config{};
+  NVTEEpGroupConfig group_config = NVTE_EP_GROUP_CONFIG_INIT;
   group_config.ep_size                  = g_ep_size;
   group_config.num_experts              = g_num_experts;
   group_config.max_tokens_per_rank      = g_max_tokens_per_rank;
@@ -156,7 +156,7 @@ static bool ep_bootstrap(int argc, char* argv[]) {
   group_config.max_token_dtype          = g_max_token_dtype;
 
   NVTE_CHECK_NCCL(ncclCommInitRank(&g_ep_comm, g_num_processes, uid, g_process_id));
-  nvte_ep_initialize(static_cast<void*>(g_ep_comm), group_config);
+  nvte_ep_initialize(static_cast<void*>(g_ep_comm), &group_config);
 
   if (g_process_id == 0) {
     printf("EP initialized: ep_size=%d num_experts=%d "
@@ -173,7 +173,7 @@ static bool ep_bootstrap(int argc, char* argv[]) {
 static void ep_reinitialize(int zero_copy) {
   if (!g_ep_initialized) return;
   nvte_ep_shutdown();
-  NVTEEpGroupConfig group_config{};
+  NVTEEpGroupConfig group_config = NVTE_EP_GROUP_CONFIG_INIT;
   group_config.ep_size                  = g_ep_size;
   group_config.num_experts              = g_num_experts;
   group_config.max_tokens_per_rank      = g_max_tokens_per_rank;
@@ -181,7 +181,7 @@ static void ep_reinitialize(int zero_copy) {
   group_config.hidden_dim               = g_hidden_dim;
   group_config.max_token_dtype          = g_max_token_dtype;
   group_config.zero_copy                = zero_copy;
-  nvte_ep_initialize(static_cast<void*>(g_ep_comm), group_config);
+  nvte_ep_initialize(static_cast<void*>(g_ep_comm), &group_config);
 }
 
 // Tear down in dependency order: backend's ep_group reads from ep_comm,

--- a/tests/jax/multi_process_launch_ep.sh
+++ b/tests/jax/multi_process_launch_ep.sh
@@ -32,6 +32,13 @@ if [ "${NUM_RUNS}" -lt 4 ]; then
   echo "NCCL EP requires at least 4 GPUs (found ${NUM_RUNS}); SKIPPING."
   exit 0
 fi
+
+# NCCL EP requires active NVLink P2P among ranks on the node.
+if ! nvidia-smi nvlink --status 2>/dev/null | grep -qE 'Link [0-9]+:.*GB/s'; then
+  echo "NVLink not detected on this platform — EP test requires NVLink; SKIPPING."
+  exit 0
+fi
+
 # Default test mesh is (2, 2); use exactly 4 ranks even on larger boxes.
 NUM_RUNS="${NVTE_TEST_EP_NUM_RANKS:-4}"
 

--- a/tests/pytorch/distributed/run_ep.py
+++ b/tests/pytorch/distributed/run_ep.py
@@ -1,0 +1,521 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""Multi-process PyTorch EP tests, launched via torchrun (one process per GPU)."""
+
+import os
+import sys
+import unittest
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from transformer_engine.pytorch.ep import (
+    EpBuffer,
+    ep_bootstrap,
+    ep_finalize,
+    ep_prepare,
+    ep_dispatch,
+    ep_combine,
+    symm_mem_alloc,
+    _ep_combine_raw,
+    _ep_dispatch_raw,
+)
+
+
+ZERO_COPY = os.environ.get("NVTE_EP_ZERO_COPY", "0") == "1"
+
+# Must come after the transformer_engine import so libtransformer_engine.so is loaded.
+import transformer_engine_torch as tex  # noqa: F401
+
+
+NUM_LOCAL_EXPERTS = 2
+HIDDEN_DIM = 32
+TOP_K = 2
+TOKENS_PER_RANK = 4
+
+
+def _zero_copy_test_include(fn):
+    """Mark a test to also run in the zero-copy pass; others skip there."""
+    fn._zero_copy_test_include = True
+    return fn
+
+
+class _StageToSymm(torch.autograd.Function):
+    """Identity op that stages ``src`` into a symm-mem buffer; grad passes through.
+    Lets a test feed a symm-mem-backed, autograd-tracked tensor into ep_combine.
+    """
+
+    @staticmethod
+    def forward(ctx, src, symm_buf):  # type: ignore[override]
+        symm_buf.copy_(src)
+        return symm_buf
+
+    @staticmethod
+    def backward(ctx, g):  # type: ignore[override]
+        return g, None
+
+
+class _GradToSymm(torch.autograd.Function):
+    """Identity fwd; bwd stages the upstream grad into a symm-mem buffer and
+    returns it, so the next backward (dispatch_bwd) receives a symm-window grad
+    input — which zero-copy ncclEpCombine requires.
+    """
+
+    @staticmethod
+    def forward(ctx, x, symm_buf):  # type: ignore[override]
+        ctx.symm_buf = symm_buf
+        return x
+
+    @staticmethod
+    def backward(ctx, g):  # type: ignore[override]
+        ctx.symm_buf.copy_(g)
+        return ctx.symm_buf, None
+
+
+def _device_sm() -> int:
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor
+
+
+def _build_ep_group():
+    """EP group spanning all ranks of the default PG."""
+    world_pg = dist.distributed_c10d._get_default_group()
+    ranks = list(range(world_pg.size()))
+    return dist.new_group(ranks=ranks, backend="nccl")
+
+
+def _make_identity_inputs(rank, ep_size, device="cuda"):
+    """Per-rank identity routing + uniform weights so combine matches tokens."""
+    T = TOKENS_PER_RANK
+    E = ep_size * NUM_LOCAL_EXPERTS
+    topk_idx = np.empty((T, TOP_K), dtype=np.int64)
+    base = rank * T
+    for t in range(T):
+        for k in range(TOP_K):
+            topk_idx[t, k] = ((base + t) * TOP_K + k) % E
+    tokens_np = np.linspace(
+        0.1 + rank * 0.01, 0.9 + rank * 0.01, T * HIDDEN_DIM, dtype=np.float32
+    ).reshape(T, HIDDEN_DIM)
+    topk_weights = np.full((T, TOP_K), 1.0 / TOP_K, dtype=np.float32)
+    return (
+        torch.from_numpy(topk_idx).to(device),
+        torch.from_numpy(tokens_np).to(device=device, dtype=torch.bfloat16),
+        torch.from_numpy(topk_weights).to(device),
+    )
+
+
+class _Cfg:
+    rank: int
+    world_size: int
+    ep_size: int
+    num_experts: int
+    recv_capacity_per_rank: int
+    device: torch.device
+
+
+def _make_cfg() -> _Cfg:
+    cfg = _Cfg()
+    cfg.rank = dist.get_rank()
+    cfg.world_size = dist.get_world_size()
+    cfg.ep_size = cfg.world_size
+    cfg.num_experts = NUM_LOCAL_EXPERTS * cfg.ep_size
+    T = TOKENS_PER_RANK
+    active = min(cfg.num_experts, T * cfg.ep_size * TOP_K)
+    overconc = cfg.num_experts // active
+    cfg.recv_capacity_per_rank = NUM_LOCAL_EXPERTS * max(T * cfg.ep_size * TOP_K, 16) * overconc * 2
+    cfg.device = torch.device("cuda", torch.cuda.current_device())
+    return cfg
+
+
+class TestEP(unittest.TestCase):
+    cfg: _Cfg
+    ep_group: dist.ProcessGroup
+
+    @classmethod
+    def setUpClass(cls):
+        if _device_sm() < 90:
+            raise unittest.SkipTest(f"NCCL EP requires SM>=90 (got SM{_device_sm()})")
+        cls.cfg = _make_cfg()
+        cls.ep_group = _build_ep_group()
+        ep_bootstrap(
+            cls.ep_group,
+            num_experts=cls.cfg.num_experts,
+            max_tokens_per_rank=TOKENS_PER_RANK,
+            recv_capacity_per_rank=cls.cfg.recv_capacity_per_rank,
+            hidden_dim=HIDDEN_DIM,
+            zero_copy=ZERO_COPY,
+        )
+
+    def setUp(self):
+        # Only the zero-copy-capable tests run in the zero-copy pass.
+        if ZERO_COPY and not getattr(
+            getattr(self, self._testMethodName), "_zero_copy_test_include", False
+        ):
+            self.skipTest("not exercised in zero-copy mode")
+
+    def _make_buffer(
+        self,
+        alignment=0,
+        top_k=TOP_K,
+        dispatch_recv_tokens=None,
+        combine_grad_expert_out=None,
+    ):
+        return EpBuffer(
+            top_k=top_k,
+            max_tokens_per_rank=TOKENS_PER_RANK,
+            recv_capacity_per_rank=self.cfg.recv_capacity_per_rank,
+            hidden_dim=HIDDEN_DIM,
+            num_local_experts=NUM_LOCAL_EXPERTS,
+            alignment=alignment,
+            dispatch_recv_tokens=dispatch_recv_tokens,
+            combine_grad_expert_out=combine_grad_expert_out,
+        )
+
+    def _expert_out(self, expert_out):
+        """Stage the combine input into symm-mem under zero-copy (combine requires it)."""
+        if not ZERO_COPY:
+            return expert_out
+        symm_buf = symm_mem_alloc(tuple(expert_out.shape), expert_out.dtype, self.ep_group)
+        return _StageToSymm.apply(expert_out, symm_buf)
+
+    def _stage_grad_symm(self, x, symm_buf=None):
+        """Route x's upstream grad through a symm-mem buffer so dispatch_bwd gets
+        a symm-window grad input under zero-copy; passthrough otherwise. Pass a
+        pre-allocated symm_buf to avoid allocating during an interleaved schedule."""
+        if not ZERO_COPY:
+            return x
+        if symm_buf is None:
+            symm_buf = symm_mem_alloc(tuple(x.shape), x.dtype, self.ep_group)
+        return _GradToSymm.apply(x, symm_buf)
+
+    def _make_raw_recv(self, dtype=torch.bfloat16):
+        """Raw recv tensors + token_counts for the primitive tests."""
+        rc = self.cfg.recv_capacity_per_rank
+        return (
+            torch.empty(rc, HIDDEN_DIM, dtype=dtype, device=self.cfg.device),
+            torch.empty(rc, dtype=torch.float32, device=self.cfg.device),
+            torch.empty(NUM_LOCAL_EXPERTS, dtype=torch.int32, device=self.cfg.device),
+        )
+
+    @staticmethod
+    def _weighted(recv_tokens, recv_w):
+        """fp32 per-slot weighting + cast back; matches the upstream combine input."""
+        mask = (recv_w != 0).to(torch.float32).unsqueeze(-1)
+        return (recv_tokens.float() * recv_w.unsqueeze(-1).float() * mask).to(recv_tokens.dtype)
+
+    def _moe_step(self, buffer, topk_idx, tokens, w):
+        recv_t, recv_w_out, _tc = ep_dispatch(buffer, tokens, topk_idx, w)
+        expert_out = self._weighted(recv_t, recv_w_out)
+        return ep_combine(buffer, expert_out)
+
+    # Prepare
+
+    def test_primitive_prepare(self):
+        buf = self._make_buffer()
+        topk_idx, _toks, _w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        token_counts = ep_prepare(buf, topk_idx)
+        torch.cuda.synchronize()
+        self.assertEqual(token_counts.shape, (NUM_LOCAL_EXPERTS,))
+        local = int(token_counts.sum().item())
+        total = torch.tensor([local], dtype=torch.int64, device=self.cfg.device)
+        dist.all_reduce(total, op=dist.ReduceOp.SUM, group=self.ep_group)
+        self.assertEqual(int(total.item()), self.cfg.world_size * TOKENS_PER_RANK * TOP_K)
+
+    # Identity round-trip via raw primitives
+
+    def test_primitive_dispatch_combine_identity(self):
+        buf = self._make_buffer()
+        topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        recv_tokens, recv_w, _ = self._make_raw_recv()
+        ep_prepare(buf, topk_idx)
+        _ep_dispatch_raw(buf, topk_idx, tokens, w, recv_tokens, recv_w)
+        result = torch.empty_like(tokens)
+        _ep_combine_raw(buf, self._weighted(recv_tokens, recv_w), result)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result.float(), tokens.float(), atol=5e-2, rtol=5e-2)
+
+    # Autograd
+
+    @_zero_copy_test_include
+    def test_dispatch_autograd(self):
+        """0.5*||recv_tokens||^2 ; grad_tokens equals TOP_K * tokens. Covers the
+        EpBuffer-owned recv tokens (symm-mem under zero-copy) and, in normal
+        mode, a caller-supplied recv_tokens buffer."""
+        if ZERO_COPY:
+            cases = [("buffer_owned", None)]
+        else:
+            rt_buf, _rw_buf, _ = self._make_raw_recv()
+            cases = [
+                ("default_alloc", None),
+                ("caller_recv", rt_buf),
+            ]
+        for label, recv_tokens in cases:
+            with self.subTest(case=label):
+                buf = self._make_buffer(dispatch_recv_tokens=recv_tokens)
+                topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+                tokens_p = tokens.detach().clone().requires_grad_(True)
+                rt, rw, _tc = ep_dispatch(buf, tokens_p, topk_idx, w)
+                if recv_tokens is not None:  # caller-supplied recv_tokens must be used in place
+                    self.assertEqual(rt.data_ptr(), recv_tokens.data_ptr())
+                rt = self._stage_grad_symm(rt)
+                rw = self._stage_grad_symm(rw)
+                (0.5 * (rt.float() ** 2).sum() + 0.0 * rw.float().sum()).backward()
+                torch.cuda.synchronize()
+                torch.testing.assert_close(
+                    tokens_p.grad.float(), tokens.float() * float(TOP_K), atol=5e-2, rtol=5e-2
+                )
+
+    @_zero_copy_test_include
+    def test_caller_provides_dispatch_recv_tokens(self):
+        """Caller-supplied recv_tokens: EpBuffer adopts it (recv_topk_weights stays
+        owned) and ep_dispatch returns a view of the caller's buffer."""
+        if ZERO_COPY:
+            rc = self.cfg.recv_capacity_per_rank
+            rt_buf = symm_mem_alloc((rc, HIDDEN_DIM), torch.bfloat16, self.ep_group)
+        else:
+            rt_buf, _rw_buf, _ = self._make_raw_recv()
+        buf = self._make_buffer(dispatch_recv_tokens=rt_buf)
+        self.assertEqual(buf.recv_tokens_symm_buf.data_ptr(), rt_buf.data_ptr())
+        if ZERO_COPY:  # recv_topk_weights is always buffer-owned in zero-copy
+            self.assertIsNotNone(buf.recv_topk_weights_symm_buf)
+        topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        tokens_p = tokens.detach().clone().requires_grad_(True)
+        rt, rw, _ = ep_dispatch(buf, tokens_p, topk_idx, w)
+        self.assertEqual(rt.data_ptr(), rt_buf.data_ptr())
+        rt = self._stage_grad_symm(rt)
+        rw = self._stage_grad_symm(rw)
+        (0.5 * (rt.float() ** 2).sum() + 0.0 * rw.float().sum()).backward()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            tokens_p.grad.float(), tokens.float() * float(TOP_K), atol=5e-2, rtol=5e-2
+        )
+
+    @_zero_copy_test_include
+    def test_caller_provides_grad_expert_out(self):
+        """Caller-supplied grad_expert_out: EpBuffer adopts it as the combine
+        backward grad target (symm-mem under zero-copy)."""
+        rc = self.cfg.recv_capacity_per_rank
+        if ZERO_COPY:
+            gbuf = symm_mem_alloc((rc, HIDDEN_DIM), torch.bfloat16, self.ep_group)
+        else:
+            gbuf = torch.empty(rc, HIDDEN_DIM, dtype=torch.bfloat16, device=self.cfg.device)
+        buf = self._make_buffer(combine_grad_expert_out=gbuf)
+        self.assertEqual(buf.grad_expert_out_symm_buf.data_ptr(), gbuf.data_ptr())
+        topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        tokens_p = tokens.detach().clone().requires_grad_(True)
+        recv_t, recv_w, _ = ep_dispatch(buf, tokens_p, topk_idx, w)
+        recv_t = self._stage_grad_symm(recv_t)
+        recv_w = self._stage_grad_symm(recv_w)
+        expert_out = self._expert_out(self._weighted(recv_t, recv_w))
+        out = ep_combine(buf, expert_out)
+        (0.5 * (out.float() ** 2).sum()).backward()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out.float(), tokens.float(), atol=5e-2, rtol=5e-2)
+        torch.testing.assert_close(tokens_p.grad.float(), tokens.float(), atol=5e-2, rtol=5e-2)
+
+    # Multi-iter stability
+
+    def test_dispatch_autograd_multiple_iterations(self):
+        """5 fwd+bwd iters on the same EpBuffer must be bit-stable."""
+        buf = self._make_buffer()
+        topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+
+        def one_step():
+            tokens_p = tokens.detach().clone().requires_grad_(True)
+            out = self._moe_step(buf, topk_idx, tokens_p, w)
+            loss = 0.5 * (out.float() ** 2).sum()
+            loss.backward()
+            return out.detach().clone(), tokens_p.grad.detach().clone()
+
+        out_ref, grad_ref = one_step()
+        torch.cuda.synchronize()
+        for _ in range(4):
+            out_i, grad_i = one_step()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(out_i, out_ref, atol=0, rtol=0)
+            torch.testing.assert_close(grad_i, grad_ref, atol=0, rtol=0)
+
+    # CUDA graph
+
+    def test_cuda_graph_capture(self):
+        """Capture raw dispatch+combine into a CUDA graph; replay must be bit-stable."""
+        buf = self._make_buffer()
+        topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        recv_tokens, recv_w, _ = self._make_raw_recv()
+        result = torch.empty_like(tokens)
+
+        def step():
+            ep_prepare(buf, topk_idx)
+            _ep_dispatch_raw(buf, topk_idx, tokens, w, recv_tokens, recv_w)
+            _ep_combine_raw(buf, self._weighted(recv_tokens, recv_w), result)
+
+        for _ in range(3):
+            step()
+        torch.cuda.synchronize()
+
+        # Routing is fixed per layer; prepare runs once before capture.
+        ep_prepare(buf, topk_idx)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            with torch.cuda.graph(graph):
+                _ep_dispatch_raw(buf, topk_idx, tokens, w, recv_tokens, recv_w)
+                _ep_combine_raw(buf, self._weighted(recv_tokens, recv_w), result)
+        torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+
+        ref = result.clone()
+        for _ in range(5):
+            graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result.float(), ref.float(), atol=0, rtol=0)
+
+    # PP-1F1B handle isolation
+
+    @_zero_copy_test_include
+    def test_pp_1f1b_two_handles(self):
+        """PP-1F1B interleave (F0 F1 B0 F2 B1 B2) over 3 per-microbatch buffers,
+        run eagerly and replayed from a CUDA graph capturing the full fwd+bwd
+        schedule (prepare included; routing is fixed so replay reproduces it)."""
+        for capture in (False, True):
+            with self.subTest(capture=capture):
+                self._run_1f1b(capture)
+
+    def _run_1f1b(self, capture):
+        T, H = TOKENS_PER_RANK, HIDDEN_DIM
+        idx, _toks, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        scales = (0.13, 0.41, 0.77)
+        buffers, tokens, tokens_p = [], [], []
+        for s in scales:
+            buffers.append(self._make_buffer())
+            t = torch.full(
+                (T, H), s + self.cfg.rank * 0.01, dtype=torch.bfloat16, device=self.cfg.device
+            )
+            tokens.append(t)
+            tokens_p.append(t.detach().clone().requires_grad_(True))
+
+        recv = [None, None, None]
+        # Per-microbatch grad-staging buffers, symm-mem under zero-copy and
+        # pre-allocated so nothing is allocated/freed mid-interleave. The recv
+        # outputs are owned by each EpBuffer (symm-mem under zero-copy).
+        recv_w = [None, None, None]
+        rc = self.cfg.recv_capacity_per_rank
+        if ZERO_COPY:
+            gbuf_t = [symm_mem_alloc((rc, H), torch.bfloat16, self.ep_group) for _ in scales]
+            gbuf_w = [symm_mem_alloc((rc,), torch.float32, self.ep_group) for _ in scales]
+        else:
+            gbuf_t = gbuf_w = [None, None, None]
+
+        def fwd(k):
+            rt, rw, _ = ep_dispatch(buffers[k], tokens_p[k], idx, w)
+            recv[k] = self._stage_grad_symm(rt, gbuf_t[k])
+            recv_w[k] = self._stage_grad_symm(rw, gbuf_w[k])
+
+        def bwd(k):
+            (0.5 * (recv[k].float() ** 2).sum() + 0.0 * recv_w[k].float().sum()).backward()
+            recv[k] = None
+            recv_w[k] = None
+
+        def interleave():
+            fwd(0)
+            fwd(1)
+            bwd(0)
+            fwd(2)
+            bwd(1)
+            bwd(2)
+
+        def zero_grads():
+            for tp in tokens_p:
+                if tp.grad is not None:
+                    tp.grad.zero_()
+
+        if not capture:
+            interleave()
+        else:
+            # Warmup on a side stream, then capture the full schedule and replay.
+            # Grads stay pre-allocated (zeroed, not None) so backward accumulates
+            # in place during both capture and replay.
+            s = torch.cuda.Stream()
+            s.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s):
+                for _ in range(3):
+                    zero_grads()
+                    interleave()
+            torch.cuda.current_stream().wait_stream(s)
+            torch.cuda.synchronize()
+
+            zero_grads()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                interleave()
+            zero_grads()
+            graph.replay()
+
+        torch.cuda.synchronize()
+        for k in range(3):
+            torch.testing.assert_close(
+                tokens_p[k].grad.float(),
+                tokens[k].float() * float(TOP_K),
+                atol=5e-2,
+                rtol=5e-2,
+            )
+
+    @_zero_copy_test_include
+    def test_combine_autograd(self):
+        """ep_combine fwd+bwd; bwd grad target is the EpBuffer symm buffer (zc) or in-flight."""
+        buf = self._make_buffer()
+        topk_idx, tokens, w = _make_identity_inputs(self.cfg.rank, self.cfg.ep_size)
+        tokens_p = tokens.detach().clone().requires_grad_(True)
+        recv_t, recv_w, _ = ep_dispatch(buf, tokens_p, topk_idx, w)
+        recv_t = self._stage_grad_symm(recv_t)
+        recv_w = self._stage_grad_symm(recv_w)
+        expert_out = self._expert_out(self._weighted(recv_t, recv_w))
+        out = ep_combine(buf, expert_out)
+        (0.5 * (out.float() ** 2).sum()).backward()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out.float(), tokens.float(), atol=5e-2, rtol=5e-2)
+        torch.testing.assert_close(tokens_p.grad.float(), tokens.float(), atol=5e-2, rtol=5e-2)
+
+    # Input validation
+
+    def test_topk_int32_raises_clear_error(self):
+        buf = self._make_buffer()
+        topk_idx_int32 = torch.zeros(
+            TOKENS_PER_RANK, TOP_K, dtype=torch.int32, device=self.cfg.device
+        )
+        with self.assertRaises(RuntimeError) as cm:
+            ep_prepare(buf, topk_idx_int32)
+        msg = str(cm.exception)
+        self.assertIn("topk_idx", msg)
+        self.assertIn(".long()", msg)
+
+
+def _init_distributed():
+    dist.init_process_group(backend="nccl")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    try:
+        from torch.distributed import _symmetric_memory as _symm_mem
+
+        _symm_mem.set_backend("NCCL")
+    except (ImportError, RuntimeError):
+        pass
+
+
+if __name__ == "__main__":
+    _init_distributed()
+    loader = unittest.TestLoader()
+    name_filter = os.environ.get("NVTE_EP_TEST_FILTER")
+    if name_filter:
+        loader.testMethodPrefix = name_filter
+    suite = loader.loadTestsFromTestCase(TestEP)
+    runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
+    result = runner.run(suite)
+    dist.barrier()
+    ep_finalize()
+    dist.destroy_process_group()
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tests/pytorch/distributed/run_test_ep.sh
+++ b/tests/pytorch/distributed/run_test_ep.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+#
+# Launcher for tests/pytorch/distributed/run_ep.py. Auto-detects GPU count.
+# Short timeout by default to surface hangs early.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TE_REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+export PYTHONPATH="${TE_REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+DETECTED_GPUS=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ "${DETECTED_GPUS}" -lt 4 ]; then
+  echo "EP requires >= 4 GPUs (found ${DETECTED_GPUS}); SKIPPING."
+  exit 0
+fi
+
+# NCCL EP requires NVLink/NVSwitch between GPUs.
+# On PCIe-only nodes (no NVLink) it falls back to the network
+# transport and deadlocks, so skip cleanly there.
+if ! nvidia-smi topo -m 2>/dev/null | grep -qE "\bNV[0-9]+\b"; then
+  echo "No NVLink between GPUs (PCIe-only fabric); NCCL EP is unsupported here. SKIPPING."
+  exit 0
+fi
+
+NUM_RANKS="${NVTE_TEST_EP_NUM_RANKS:-${DETECTED_GPUS}}"
+if [ "${NUM_RANKS}" -gt 8 ]; then NUM_RANKS=8; fi
+
+# Short timeout to detect hangs early.
+TEST_TIMEOUT_S="${TEST_TIMEOUT_S:-120}"
+
+# Stage NCCL EP JIT cubins on tmpfs to keep iteration fast.
+: ${NCCL_EP_JIT_CACHE_DIR:="${TMPDIR:-/tmp}/nccl_ep_jit_cache_$(id -u)"}
+export NCCL_EP_JIT_CACHE_DIR
+mkdir -p "$NCCL_EP_JIT_CACHE_DIR"
+
+SCRIPT="${SCRIPT_DIR}/run_ep.py"
+
+RET=0
+
+# Run the suite once per IO mode. Modes can't be mixed in one process
+# (ep_bootstrap is once-per-process), so zero-copy gets its own run; only the
+# zero-copy-capable tests execute there (the rest self-skip).
+run_pass() {
+  local label="$1"
+  local zc="$2"
+  local log="stdout_ep_${label}.txt"
+  echo "=== Running ${SCRIPT} [${label}] on ${NUM_RANKS} GPUs (timeout=${TEST_TIMEOUT_S}s) ==="
+  # setsid + kill-after so SIGKILL takes down the whole process group, not just torchrun.
+  NVTE_EP_ZERO_COPY="${zc}" setsid timeout --foreground --kill-after=10 --signal=TERM \
+    "${TEST_TIMEOUT_S}" \
+    torchrun --standalone --nnodes=1 --nproc-per-node="${NUM_RANKS}" \
+    "${SCRIPT}" 2>&1 | tee "${log}"
+  local rc=${PIPESTATUS[0]}
+  pkill -9 -f "tests/pytorch/distributed/run_ep.py" 2>/dev/null || true
+
+  if [ "${rc}" -ne 0 ]; then echo "[${label}] torchrun exited with ${rc}"; RET=1; fi
+  # Match unittest failure markers and unhandled Python tracebacks; torchrun
+  # prefixes per-rank stderr with "[rankN]:" so don't anchor at column 0.
+  if grep -qE "(^|]:)FAILED|(^|]:)Traceback" "${log}"; then RET=1; fi
+  if ! grep -qE "Ran [0-9]+ test|^OK$" "${log}"; then
+    echo "[${label}] ERROR: no test summary — likely hang or early crash"
+    RET=1
+  fi
+  if [ -z "${KEEP_EP_LOGS:-}" ]; then rm -f "${log}"; fi
+}
+
+run_pass "default" 0
+run_pass "zero_copy" 1
+
+exit $RET

--- a/tests/pytorch/distributed/run_test_ep.sh
+++ b/tests/pytorch/distributed/run_test_ep.sh
@@ -18,10 +18,10 @@ if [ "${DETECTED_GPUS}" -lt 4 ]; then
   exit 0
 fi
 
-# NCCL EP requires NVLink/NVSwitch between GPUs.
+# NCCL EP requires active NVLink P2P among ranks on the node.
 # On PCIe-only nodes (no NVLink) it falls back to the network
 # transport and deadlocks, so skip cleanly there.
-if ! nvidia-smi topo -m 2>/dev/null | grep -qE "\bNV[0-9]+\b"; then
+if ! nvidia-smi nvlink --status 2>/dev/null | grep -qE 'Link [0-9]+:.*GB/s'; then
   echo "No NVLink between GPUs (PCIe-only fabric); NCCL EP is unsupported here. SKIPPING."
   exit 0
 fi

--- a/tests/pytorch/distributed/test_ep.py
+++ b/tests/pytorch/distributed/test_ep.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""Pytest driver — spawns run_ep.py under torchrun and asserts the suite passed."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+
+TEST_ROOT = Path(__file__).parent.resolve()
+WORKER = TEST_ROOT / "run_ep.py"
+LAUNCHER = TEST_ROOT / "run_test_ep.sh"
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="EP requires >= 4 GPUs")
+def test_multi_process_ep():
+    """Launch the EP unit-test suite across all visible GPUs.
+
+    Short timeout so a hang on any rank surfaces fast rather than burning CI time.
+    """
+    timeout_s = int(os.environ.get("NVTE_TEST_EP_TIMEOUT_S", "180"))
+    proc = subprocess.run(
+        ["bash", str(LAUNCHER)],
+        env={**os.environ, "KEEP_EP_LOGS": "1", "TEST_TIMEOUT_S": str(timeout_s)},
+        timeout=timeout_s + 30,
+        check=False,
+    )
+    assert proc.returncode == 0, f"EP test suite failed (rc={proc.returncode})"

--- a/tests/pytorch/test_backward_override.py
+++ b/tests/pytorch/test_backward_override.py
@@ -859,6 +859,218 @@ def test_backward_override_recipe_matches_requested_mode(
 
 
 @pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)
+@pytest.mark.parametrize("use_bias", (False, True), ids=("no_bias", "bias"))
+def test_linear_backward_override_dequantized_ignores_save_original_input(
+    recipe_name: str,
+    use_bias: bool,
+) -> None:
+    reset_rng_states()
+    dtype = torch.bfloat16
+    input_shape = (32, 128)
+    out_features = 128
+    _maybe_skip_recipe_dtype(recipe_name, dtype, "linear")
+    _maybe_skip_unsupported_recipe_module_combo(recipe_name, "linear")
+    _maybe_skip_unsupported_recipe_shape(recipe_name, input_shape, "linear")
+
+    mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
+    skip_unsupported_backward_override("linear", mode_recipe, "dequantized")
+
+    module_ref = te.Linear(
+        input_shape[-1],
+        out_features,
+        bias=use_bias,
+        params_dtype=dtype,
+        device="cuda",
+        save_original_input=False,
+    )
+    module_test = te.Linear(
+        input_shape[-1],
+        out_features,
+        bias=use_bias,
+        params_dtype=dtype,
+        device="cuda",
+        save_original_input=True,
+    )
+    _copy_named_parameters(module_ref, module_test)
+
+    x = torch.randn(*input_shape, dtype=dtype, device="cuda")
+    dy = torch.randn(input_shape[0], out_features, dtype=dtype, device="cuda")
+
+    y_ref, dx_ref, dw_ref, db_ref = _run_single_step(module_ref, x, dy, mode_recipe)
+    y_test, x_test, saved_operands = _run_single_step_with_saved_operands(
+        module_test, x, mode_recipe
+    )
+    _assert_saved_quantized_operand_uses_rowwise_only(saved_operands[0], name="linear_input")
+
+    y_test_detached = y_test.detach().clone()
+    y_test.backward(dy)
+    assert x_test.grad is not None
+    assert module_test.weight.grad is not None
+    dx_test = x_test.grad.detach().clone()
+    dw_test = module_test.weight.grad.detach().clone()
+    test_bias = getattr(module_test, "bias", None)
+    db_test = (
+        None if test_bias is None or test_bias.grad is None else test_bias.grad.detach().clone()
+    )
+
+    assert_close(y_test_detached, y_ref, rtol=0, atol=0, check_dtype=True)
+    assert_close(dx_test, dx_ref, rtol=0, atol=0, check_dtype=True)
+    assert_close(dw_test, dw_ref, rtol=0, atol=0, check_dtype=True)
+    if use_bias:
+        assert db_test is not None and db_ref is not None
+        assert_close(db_test, db_ref, rtol=0, atol=0, check_dtype=True)
+
+
+@pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)
+@pytest.mark.parametrize("use_bias", (False, True), ids=("no_bias", "bias"))
+def test_grouped_linear_backward_override_dequantized_ignores_save_original_input(
+    recipe_name: str,
+    use_bias: bool,
+) -> None:
+    reset_rng_states()
+    dtype = torch.bfloat16
+    in_features = 128
+    out_features = 128
+    m_splits = [64, 64]
+    num_gemms = len(m_splits)
+    num_tokens = sum(m_splits)
+    _maybe_skip_recipe_dtype(recipe_name, dtype, "grouped_linear")
+    _maybe_skip_unsupported_recipe_module_combo(recipe_name, "grouped_linear")
+    _maybe_skip_unsupported_grouped_splits(recipe_name, m_splits)
+
+    mode_recipe = make_recipe(recipe_name, backward_override="dequantized")
+    skip_unsupported_backward_override("grouped_linear", mode_recipe, "dequantized")
+
+    module_ref = te.GroupedLinear(
+        num_gemms,
+        in_features,
+        out_features,
+        bias=use_bias,
+        params_dtype=dtype,
+        device="cuda",
+        save_original_input=False,
+    )
+    module_test = te.GroupedLinear(
+        num_gemms,
+        in_features,
+        out_features,
+        bias=use_bias,
+        params_dtype=dtype,
+        device="cuda",
+        save_original_input=True,
+    )
+    _copy_named_parameters(module_ref, module_test)
+
+    x = torch.randn(num_tokens, in_features, dtype=dtype, device="cuda")
+    dy = torch.randn(num_tokens, out_features, dtype=dtype, device="cuda")
+
+    y_ref, dx_ref, dw_ref, db_ref = _run_grouped_linear_single_step(
+        module_ref, x, m_splits, dy, mode_recipe
+    )
+    y_test, x_test, saved_operands = _run_grouped_linear_step_with_saved_operands(
+        module_test, x, m_splits, mode_recipe
+    )
+    saved_inputs = saved_operands[:num_gemms]
+    for i, saved_input in enumerate(saved_inputs):
+        _assert_saved_quantized_operand_uses_rowwise_only(
+            saved_input, name=f"grouped_linear_input{i}"
+        )
+
+    y_test_detached = y_test.detach().clone()
+    y_test.backward(dy)
+    assert x_test.grad is not None
+    dx_test = x_test.grad.detach().clone()
+    dw_test = [getattr(module_test, f"weight{i}").grad.detach().clone() for i in range(num_gemms)]
+    db_test: list[Optional[torch.Tensor]] = []
+    for i in range(num_gemms):
+        if use_bias:
+            db_test.append(getattr(module_test, f"bias{i}").grad.detach().clone())
+        else:
+            db_test.append(None)
+
+    assert_close(y_test_detached, y_ref, rtol=0, atol=0, check_dtype=True)
+    assert_close(dx_test, dx_ref, rtol=0, atol=0, check_dtype=True)
+    for test_dw, ref_dw in zip(dw_test, dw_ref):
+        assert_close(test_dw, ref_dw, rtol=0, atol=0, check_dtype=True)
+    if use_bias:
+        for test_db, ref_db in zip(db_test, db_ref):
+            assert test_db is not None and ref_db is not None
+            assert_close(test_db, ref_db, rtol=0, atol=0, check_dtype=True)
+
+
+@pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)
+def test_linear_backward_override_high_precision_forces_save_original_input(
+    recipe_name: str,
+) -> None:
+    reset_rng_states()
+    dtype = torch.bfloat16
+    input_shape = (32, 128)
+    _maybe_skip_recipe_dtype(recipe_name, dtype, "linear")
+    _maybe_skip_unsupported_recipe_module_combo(recipe_name, "linear")
+    _maybe_skip_unsupported_recipe_shape(recipe_name, input_shape, "linear")
+
+    mode_recipe = make_recipe(recipe_name, backward_override="high_precision")
+    skip_unsupported_backward_override("linear", mode_recipe, "high_precision")
+
+    module = te.Linear(
+        input_shape[-1],
+        128,
+        bias=False,
+        params_dtype=dtype,
+        device="cuda",
+        save_original_input=False,
+    )
+    x = torch.randn(*input_shape, dtype=dtype, device="cuda")
+
+    _, _, saved_operands = _run_single_step_with_saved_operands(module, x, mode_recipe)
+
+    assert isinstance(saved_operands[0], torch.Tensor)
+
+
+@pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)
+def test_grouped_linear_backward_override_high_precision_forces_save_original_input(
+    recipe_name: str,
+) -> None:
+    reset_rng_states()
+    dtype = torch.bfloat16
+    in_features = 128
+    out_features = 128
+    m_splits = [64, 64]
+    num_gemms = len(m_splits)
+    num_tokens = sum(m_splits)
+    _maybe_skip_recipe_dtype(recipe_name, dtype, "grouped_linear")
+    _maybe_skip_unsupported_recipe_module_combo(recipe_name, "grouped_linear")
+    _maybe_skip_unsupported_grouped_splits(recipe_name, m_splits)
+
+    mode_recipe = make_recipe(recipe_name, backward_override="high_precision")
+    skip_unsupported_backward_override("grouped_linear", mode_recipe, "high_precision")
+
+    module = te.GroupedLinear(
+        num_gemms,
+        in_features,
+        out_features,
+        bias=False,
+        params_dtype=dtype,
+        device="cuda",
+        save_original_input=False,
+    )
+    x = torch.randn(num_tokens, in_features, dtype=dtype, device="cuda")
+
+    _, _, saved_operands = _run_grouped_linear_step_with_saved_operands(
+        module, x, m_splits, mode_recipe
+    )
+
+    saved_inputs = saved_operands[:num_gemms]
+    assert isinstance(saved_inputs[0], torch.Tensor)
+    assert saved_inputs[0].shape == x.shape
+    assert all(saved_input is None for saved_input in saved_inputs[1:])
+
+    saved_weights = saved_operands[2 * num_gemms : 3 * num_gemms]
+    for saved_weight in saved_weights:
+        assert isinstance(saved_weight, torch.Tensor)
+
+
+@pytest.mark.parametrize("recipe_name", _quantized_numerics_recipe_list)
 @pytest.mark.parametrize("module_type", ("linear", "layernorm_linear", "ops_linear"))
 @pytest.mark.parametrize("input_shape,out_features", _shape_test_cases)
 @pytest.mark.parametrize("use_bias", (False, True), ids=("no_bias", "bias"))

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -24,6 +24,7 @@ import transformer_engine_torch as tex
 from transformer_engine.common import recipe
 from transformer_engine.pytorch.constants import FP8FwdTensorIdx, FP8BwdTensorIdx
 from transformer_engine.pytorch.module.base import TransformerEngineBaseModule
+from transformer_engine.pytorch.quantization import QuantizerRole
 from transformer_engine.pytorch.ops.basic.basic_linear import BasicLinear
 from transformer_engine.pytorch.tensor.float8_tensor import Float8CurrentScalingQuantizer
 from transformer_engine.pytorch.quantization import QuantizerRole
@@ -32,6 +33,14 @@ from transformer_engine.pytorch import (
     is_mxfp8_available,
     is_fp8_block_scaling_available,
     is_nvfp4_available,
+    Float8Quantizer,
+    Float8BlockQuantizer,
+    MXFP8Quantizer,
+    NVFP4Quantizer,
+)
+from transformer_engine.pytorch.dynamo import (
+    register_value_opaque_quantizer,
+    _quantizer_from_value_key,
 )
 from utils import recipe_id
 
@@ -384,3 +393,148 @@ def test_autocast_sanity(fp8_recipe):
 
     out = compiled(inp)
     out.sum().backward()
+
+
+# ---------------------------------------------------------------------------
+# Value-opaque quantizers: eager value semantics + FX reconstruction
+#
+# The tensorless quantizers (current-scaling FP8, FP8 blockwise, MXFP8, NVFP4)
+# are torch.compile *value* opaque types: they provide value-based
+# ``__eq__`` / ``__hash__`` and an evaluable ``__fx_repr__`` (see
+# ``torch._library.opaque_object`` Note [Opaque Objects]). These tests exercise
+# the eager value semantics and the FX reconstruction round-trip. They are
+# CPU-friendly except for NVFP4 (whose constructor touches the current CUDA
+# device).
+# ---------------------------------------------------------------------------
+
+
+def _mxfp8(dtype=tex.DType.kFloat8E4M3, rowwise=True, columnwise=True):
+    return MXFP8Quantizer(fp8_dtype=dtype, rowwise=rowwise, columnwise=columnwise)
+
+
+def _blockwise(dtype=tex.DType.kFloat8E4M3, force_pow_2_scales=True, block_scaling_dim=2):
+    return Float8BlockQuantizer(
+        fp8_dtype=dtype,
+        rowwise=True,
+        columnwise=True,
+        force_pow_2_scales=force_pow_2_scales,
+        block_scaling_dim=block_scaling_dim,
+    )
+
+
+def _current_scaling(dtype=tex.DType.kFloat8E4M3, force_pow_2_scales=False, amax_epsilon=0.0):
+    return Float8CurrentScalingQuantizer(
+        fp8_dtype=dtype,
+        device=torch.device("cpu"),
+        force_pow_2_scales=force_pow_2_scales,
+        amax_epsilon=amax_epsilon,
+    )
+
+
+# (factory, kwargs_for_a_different_but_valid_config)
+_CPU_VALUE_QUANTIZERS = [
+    pytest.param(_mxfp8, {"dtype": tex.DType.kFloat8E5M2}, id="mxfp8"),
+    pytest.param(_blockwise, {"force_pow_2_scales": False}, id="float8_blockwise"),
+    pytest.param(_current_scaling, {"amax_epsilon": 1e-4}, id="float8_current_scaling"),
+]
+
+
+@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
+def test_quantizer_value_equality(factory, other_kwargs):
+    """Same config -> equal & same hash; different config -> not equal."""
+    a = factory()
+    b = factory()
+    assert a is not b
+    assert a == b
+    assert hash(a) == hash(b)
+
+    c = factory(**other_kwargs)
+    assert a != c
+    # Usage flags participate in the value.
+    d = factory()
+    d.set_usage(rowwise=False, columnwise=False)
+    assert a != d
+
+
+@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
+def test_quantizer_usable_in_set_and_dict(factory, other_kwargs):
+    a = factory()
+    b = factory()
+    c = factory(**other_kwargs)
+    assert len({a, b, c}) == 2
+    mapping = {a: "x"}
+    assert mapping[b] == "x"
+
+
+@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
+def test_quantizer_cross_type_inequality(factory, other_kwargs):
+    a = factory()
+    other = _current_scaling() if not isinstance(a, Float8CurrentScalingQuantizer) else _mxfp8()
+    assert a != other
+
+
+@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
+def test_quantizer_fx_repr_roundtrip(factory, other_kwargs):
+    """``__fx_repr__`` returns an evaluable expression rebuilding an equal object."""
+    a = factory()
+    repr_str, globals_ = a.__fx_repr__()
+    assert isinstance(repr_str, str)
+    assert isinstance(globals_, dict)
+    rebuilt = eval(repr_str, dict(globals_))  # pylint: disable=eval-used
+    assert rebuilt == a
+    assert rebuilt is not a
+    assert hash(rebuilt) == hash(a)
+
+
+@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
+def test_quantizer_value_key_reconstruction(factory, other_kwargs):
+    a = factory()
+    rebuilt = _quantizer_from_value_key(a._value_key())
+    assert type(rebuilt) is type(a)
+    assert rebuilt == a
+    # The deprecated amax-reduction process group is never carried in the value.
+    assert getattr(rebuilt, "amax_reduction_group", None) is None
+
+
+def test_quantizer_delayed_scaling_keeps_identity_semantics():
+    """Float8Quantizer holds live tensors -> identity (not value) semantics."""
+    scale = torch.ones(1)
+    amax = torch.zeros(1)
+    a = Float8Quantizer(scale=scale, amax=amax, fp8_dtype=tex.DType.kFloat8E4M3)
+    b = Float8Quantizer(scale=scale, amax=amax, fp8_dtype=tex.DType.kFloat8E4M3)
+    assert a._value_fields() is None
+    assert a == a
+    assert a != b  # distinct instances are not equal despite identical config
+    assert hash(a) == object.__hash__(a)
+
+
+@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
+def test_quantizer_registration_is_idempotent_and_tolerant(factory, other_kwargs):
+    """Re-registering must not raise, regardless of PyTorch opaque-object support."""
+    cls = type(factory())
+    register_value_opaque_quantizer(cls)
+    register_value_opaque_quantizer(cls)
+
+    if not _opaque_available:
+        pytest.skip("PyTorch build without opaque-object API")
+    from torch._library.opaque_object import is_opaque_value_type
+
+    assert is_opaque_value_type(cls)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="NVFP4Quantizer requires CUDA")
+def test_quantizer_nvfp4_value_semantics():
+    a = NVFP4Quantizer(fp4_dtype=tex.DType.kFloat4E2M1)
+    b = NVFP4Quantizer(fp4_dtype=tex.DType.kFloat4E2M1)
+    assert a == b
+    assert hash(a) == hash(b)
+
+    c = NVFP4Quantizer(fp4_dtype=tex.DType.kFloat4E2M1, with_rht=not a.with_rht)
+    assert a != c
+
+    rebuilt = _quantizer_from_value_key(a._value_key())
+    assert rebuilt == a
+    assert rebuilt.amax_reduction_group is None
+
+    repr_str, globals_ = a.__fx_repr__()
+    assert eval(repr_str, dict(globals_)) == a  # pylint: disable=eval-used

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -36,11 +36,6 @@ from transformer_engine.pytorch import (
     Float8Quantizer,
     Float8BlockQuantizer,
     MXFP8Quantizer,
-    NVFP4Quantizer,
-)
-from transformer_engine.pytorch.dynamo import (
-    register_value_opaque_quantizer,
-    _quantizer_from_value_key,
 )
 from utils import recipe_id
 
@@ -396,145 +391,60 @@ def test_autocast_sanity(fp8_recipe):
 
 
 # ---------------------------------------------------------------------------
-# Value-opaque quantizers: eager value semantics + FX reconstruction
+# Value-opaque quantizers
 #
-# The tensorless quantizers (current-scaling FP8, FP8 blockwise, MXFP8, NVFP4)
-# are torch.compile *value* opaque types: they provide value-based
-# ``__eq__`` / ``__hash__`` and an evaluable ``__fx_repr__`` (see
-# ``torch._library.opaque_object`` Note [Opaque Objects]). These tests exercise
-# the eager value semantics and the FX reconstruction round-trip. They are
-# CPU-friendly except for NVFP4 (whose constructor touches the current CUDA
-# device).
+# Tensorless quantizers (MXFP8, FP8 blockwise, FP8 current-scaling) are
+# torch.compile *value* opaque types: value-based ``__eq__`` / ``__hash__`` plus
+# an evaluable ``__fx_repr__`` that rebuilds an equal object (see
+# ``torch._library.opaque_object`` Note [Opaque Objects]).
 # ---------------------------------------------------------------------------
 
 
-def _mxfp8(dtype=tex.DType.kFloat8E4M3, rowwise=True, columnwise=True):
-    return MXFP8Quantizer(fp8_dtype=dtype, rowwise=rowwise, columnwise=columnwise)
+def _mxfp8(dtype=tex.DType.kFloat8E4M3):
+    return MXFP8Quantizer(fp8_dtype=dtype)
 
 
-def _blockwise(dtype=tex.DType.kFloat8E4M3, force_pow_2_scales=True, block_scaling_dim=2):
+def _blockwise(force_pow_2_scales=True):
     return Float8BlockQuantizer(
-        fp8_dtype=dtype,
+        fp8_dtype=tex.DType.kFloat8E4M3,
         rowwise=True,
         columnwise=True,
         force_pow_2_scales=force_pow_2_scales,
-        block_scaling_dim=block_scaling_dim,
     )
 
 
-def _current_scaling(dtype=tex.DType.kFloat8E4M3, force_pow_2_scales=False, amax_epsilon=0.0):
+def _current_scaling(amax_epsilon=0.0):
     return Float8CurrentScalingQuantizer(
-        fp8_dtype=dtype,
+        fp8_dtype=tex.DType.kFloat8E4M3,
         device=torch.device("cpu"),
-        force_pow_2_scales=force_pow_2_scales,
         amax_epsilon=amax_epsilon,
     )
 
 
-# (factory, kwargs_for_a_different_but_valid_config)
-_CPU_VALUE_QUANTIZERS = [
+# (factory, kwargs producing a different-but-valid config)
+_VALUE_QUANTIZERS = [
     pytest.param(_mxfp8, {"dtype": tex.DType.kFloat8E5M2}, id="mxfp8"),
     pytest.param(_blockwise, {"force_pow_2_scales": False}, id="float8_blockwise"),
     pytest.param(_current_scaling, {"amax_epsilon": 1e-4}, id="float8_current_scaling"),
 ]
 
 
-@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
-def test_quantizer_value_equality(factory, other_kwargs):
-    """Same config -> equal & same hash; different config -> not equal."""
-    a = factory()
-    b = factory()
+@pytest.mark.parametrize("factory, other_kwargs", _VALUE_QUANTIZERS)
+def test_quantizer_value_object(factory, other_kwargs):
+    """Value semantics + ``__fx_repr__`` round-trip via the production FX path."""
+    a, b = factory(), factory()
+    # Same config -> equal, same hash, interchangeable as a dict/set key.
     assert a is not b
     assert a == b
     assert hash(a) == hash(b)
+    assert {a: "x"}[b] == "x"
+    # Different config -> not equal.
+    assert a != factory(**other_kwargs)
 
-    c = factory(**other_kwargs)
-    assert a != c
-    # Usage flags participate in the value.
-    d = factory()
-    d.set_usage(rowwise=False, columnwise=False)
-    assert a != d
-
-
-@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
-def test_quantizer_usable_in_set_and_dict(factory, other_kwargs):
-    a = factory()
-    b = factory()
-    c = factory(**other_kwargs)
-    assert len({a, b, c}) == 2
-    mapping = {a: "x"}
-    assert mapping[b] == "x"
-
-
-@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
-def test_quantizer_cross_type_inequality(factory, other_kwargs):
-    a = factory()
-    other = _current_scaling() if not isinstance(a, Float8CurrentScalingQuantizer) else _mxfp8()
-    assert a != other
-
-
-@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
-def test_quantizer_fx_repr_roundtrip(factory, other_kwargs):
-    """``__fx_repr__`` returns an evaluable expression rebuilding an equal object."""
-    a = factory()
+    # ``__fx_repr__`` (used by torch.compile codegen) rebuilds an equal object.
     repr_str, globals_ = a.__fx_repr__()
-    assert isinstance(repr_str, str)
-    assert isinstance(globals_, dict)
     rebuilt = eval(repr_str, dict(globals_))  # pylint: disable=eval-used
-    assert rebuilt == a
-    assert rebuilt is not a
+    assert rebuilt == a and rebuilt is not a
     assert hash(rebuilt) == hash(a)
-
-
-@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
-def test_quantizer_value_key_reconstruction(factory, other_kwargs):
-    a = factory()
-    rebuilt = _quantizer_from_value_key(a._value_key())
-    assert type(rebuilt) is type(a)
-    assert rebuilt == a
-    # The deprecated amax-reduction process group is never carried in the value.
+    # The deprecated amax-reduction group is never part of the value.
     assert getattr(rebuilt, "amax_reduction_group", None) is None
-
-
-def test_quantizer_delayed_scaling_keeps_identity_semantics():
-    """Float8Quantizer holds live tensors -> identity (not value) semantics."""
-    scale = torch.ones(1)
-    amax = torch.zeros(1)
-    a = Float8Quantizer(scale=scale, amax=amax, fp8_dtype=tex.DType.kFloat8E4M3)
-    b = Float8Quantizer(scale=scale, amax=amax, fp8_dtype=tex.DType.kFloat8E4M3)
-    assert a._value_fields() is None
-    assert a == a
-    assert a != b  # distinct instances are not equal despite identical config
-    assert hash(a) == object.__hash__(a)
-
-
-@pytest.mark.parametrize("factory, other_kwargs", _CPU_VALUE_QUANTIZERS)
-def test_quantizer_registration_is_idempotent_and_tolerant(factory, other_kwargs):
-    """Re-registering must not raise, regardless of PyTorch opaque-object support."""
-    cls = type(factory())
-    register_value_opaque_quantizer(cls)
-    register_value_opaque_quantizer(cls)
-
-    if not _opaque_available:
-        pytest.skip("PyTorch build without opaque-object API")
-    from torch._library.opaque_object import is_opaque_value_type
-
-    assert is_opaque_value_type(cls)
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="NVFP4Quantizer requires CUDA")
-def test_quantizer_nvfp4_value_semantics():
-    a = NVFP4Quantizer(fp4_dtype=tex.DType.kFloat4E2M1)
-    b = NVFP4Quantizer(fp4_dtype=tex.DType.kFloat4E2M1)
-    assert a == b
-    assert hash(a) == hash(b)
-
-    c = NVFP4Quantizer(fp4_dtype=tex.DType.kFloat4E2M1, with_rht=not a.with_rht)
-    assert a != c
-
-    rebuilt = _quantizer_from_value_key(a._value_key())
-    assert rebuilt == a
-    assert rebuilt.amax_reduction_group is None
-
-    repr_str, globals_ = a.__fx_repr__()
-    assert eval(repr_str, dict(globals_)) == a  # pylint: disable=eval-used

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -27,7 +27,7 @@ from transformer_engine.pytorch.module.base import TransformerEngineBaseModule
 from transformer_engine.pytorch.quantization import QuantizerRole
 from transformer_engine.pytorch.ops.basic.basic_linear import BasicLinear
 from transformer_engine.pytorch.tensor.float8_tensor import Float8CurrentScalingQuantizer
-from transformer_engine.pytorch.quantization import QuantizerRole
+from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
 from transformer_engine.pytorch import (
     is_fp8_available,
     is_mxfp8_available,
@@ -416,11 +416,29 @@ def _current_scaling(amax_epsilon=0.0):
     )
 
 
+def _nvfp4(with_rht=False):
+    return NVFP4Quantizer(
+        fp4_dtype=tex.DType.kFloat4E2M1,
+        rowwise=True,
+        columnwise=True,
+        with_rht=with_rht,
+    )
+
+
 # (factory, kwargs producing a different-but-valid config)
 _VALUE_QUANTIZERS = [
     pytest.param(_mxfp8, {"dtype": tex.DType.kFloat8E5M2}, id="mxfp8"),
     pytest.param(_blockwise, {"force_pow_2_scales": False}, id="float8_blockwise"),
     pytest.param(_current_scaling, {"amax_epsilon": 1e-4}, id="float8_current_scaling"),
+    pytest.param(
+        _nvfp4,
+        {"with_rht": True},
+        id="nvfp4",
+        marks=pytest.mark.skipif(
+            not torch.cuda.is_available(),
+            reason="NVFP4Quantizer requires CUDA to construct",
+        ),
+    ),
 ]
 
 

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -392,11 +392,6 @@ def test_autocast_sanity(fp8_recipe):
 
 # ---------------------------------------------------------------------------
 # Value-opaque quantizers
-#
-# Tensorless quantizers (MXFP8, FP8 blockwise, FP8 current-scaling) are
-# torch.compile *value* opaque types: value-based ``__eq__`` / ``__hash__`` plus
-# an evaluable ``__fx_repr__`` that rebuilds an equal object (see
-# ``torch._library.opaque_object`` Note [Opaque Objects]).
 # ---------------------------------------------------------------------------
 
 
@@ -446,5 +441,3 @@ def test_quantizer_value_object(factory, other_kwargs):
     rebuilt = eval(repr_str, dict(globals_))  # pylint: disable=eval-used
     assert rebuilt == a and rebuilt is not a
     assert hash(rebuilt) == hash(a)
-    # The deprecated amax-reduction group is never part of the value.
-    assert getattr(rebuilt, "amax_reduction_group", None) is None

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -416,13 +416,27 @@ def _current_scaling(amax_epsilon=0.0):
     )
 
 
-def _nvfp4(with_rht=False):
+def _nvfp4(with_rht=True):
+    # Default with_rht=True so the quantize round-trip below exercises the
+    # derived ``rht_matrix`` tensor (the field most likely to be dropped on
+    # value-key reconstruction).
     return NVFP4Quantizer(
         fp4_dtype=tex.DType.kFloat4E2M1,
         rowwise=True,
         columnwise=True,
         with_rht=with_rht,
     )
+
+
+def _hw_available(quantizer):
+    """Whether this HW can actually run the quantize kernel for *quantizer*."""
+    if isinstance(quantizer, MXFP8Quantizer):
+        return mxfp8_available
+    if isinstance(quantizer, NVFP4Quantizer):
+        return nvfp4_available
+    if isinstance(quantizer, Float8BlockQuantizer):
+        return fp8_block_scaling_available
+    return fp8_available  # Float8CurrentScalingQuantizer
 
 
 # (factory, kwargs producing a different-but-valid config)
@@ -432,7 +446,7 @@ _VALUE_QUANTIZERS = [
     pytest.param(_current_scaling, {"amax_epsilon": 1e-4}, id="float8_current_scaling"),
     pytest.param(
         _nvfp4,
-        {"with_rht": True},
+        {"with_rht": False},
         id="nvfp4",
         marks=pytest.mark.skipif(
             not torch.cuda.is_available(),
@@ -459,6 +473,15 @@ def test_quantizer_value_object(factory, other_kwargs):
     rebuilt = eval(repr_str, dict(globals_))  # pylint: disable=eval-used
     assert rebuilt == a and rebuilt is not a
     assert hash(rebuilt) == hash(a)
+
+    # The rebuilt quantizer must also *behave* identically, not just compare
+    # equal: equality only looks at the value key, so a field the kernel needs
+    # but that is absent from the key (e.g. NVFP4's derived ``rht_matrix``) would
+    # slip through the checks above and only blow up at quantize time. Run the
+    # real quantize kernel on both and require bit-exact results.
+    if torch.cuda.is_available() and _hw_available(a):
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        torch.testing.assert_close(rebuilt(x).dequantize(), a(x).dequantize(), rtol=0.0, atol=0.0)
 
 
 @pytest.mark.skipif(

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -441,12 +441,11 @@ def _hw_available(quantizer):
 
 # (factory, kwargs producing a different-but-valid config)
 _VALUE_QUANTIZERS = [
-    pytest.param(_mxfp8, {"dtype": tex.DType.kFloat8E5M2}, id="mxfp8"),
-    pytest.param(_blockwise, {"force_pow_2_scales": False}, id="float8_blockwise"),
-    pytest.param(_current_scaling, {"amax_epsilon": 1e-4}, id="float8_current_scaling"),
+    pytest.param(_mxfp8, id="mxfp8"),
+    pytest.param(_blockwise, id="float8_blockwise"),
+    pytest.param(_current_scaling, id="float8_current_scaling"),
     pytest.param(
         _nvfp4,
-        {"with_rht": False},
         id="nvfp4",
         marks=pytest.mark.skipif(
             not torch.cuda.is_available(),
@@ -456,17 +455,10 @@ _VALUE_QUANTIZERS = [
 ]
 
 
-@pytest.mark.parametrize("factory, other_kwargs", _VALUE_QUANTIZERS)
-def test_quantizer_value_object(factory, other_kwargs):
+@pytest.mark.parametrize("factory", _VALUE_QUANTIZERS)
+def test_quantizer_value_object(factory):
     """Value semantics + ``__fx_repr__`` round-trip via the production FX path."""
-    a, b = factory(), factory()
-    # Same config -> equal, same hash, interchangeable as a dict/set key.
-    assert a is not b
-    assert a == b
-    assert hash(a) == hash(b)
-    assert {a: "x"}[b] == "x"
-    # Different config -> not equal.
-    assert a != factory(**other_kwargs)
+    a = factory()
 
     # ``__fx_repr__`` (used by torch.compile codegen) rebuilds an equal object.
     repr_str, globals_ = a.__fx_repr__()
@@ -538,8 +530,8 @@ if _opaque_available:
     not _opaque_available,
     reason="torch.compile opaque-object support requires PyTorch >= 2.11",
 )
-@pytest.mark.parametrize("factory, other_kwargs", _VALUE_QUANTIZERS)
-def test_quantizer_value_object_fullgraph(factory, other_kwargs):
+@pytest.mark.parametrize("factory", _VALUE_QUANTIZERS)
+def test_quantizer_value_object_fullgraph(factory):
     """Quantizer is usable *inside* a torch.compile(fullgraph=True) graph.
 
     A custom op quantizes+dequantizes with the (opaque value) quantizer; the

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -484,6 +484,27 @@ def test_quantizer_value_object(factory, other_kwargs):
         torch.testing.assert_close(rebuilt(x).dequantize(), a(x).dequantize(), rtol=0.0, atol=0.0)
 
 
+def test_value_quantizer_rejects_process_group():
+    """A value quantizer holding a live ProcessGroup must refuse to be turned
+    into a value key / FX constant (raise), not silently drop the group."""
+    import torch.distributed as dist  # pylint: disable=import-outside-toplevel
+
+    created = not dist.is_initialized()
+    if created:
+        dist.init_process_group(backend="gloo", store=dist.HashStore(), rank=0, world_size=1)
+    try:
+        q = MXFP8Quantizer(fp8_dtype=tex.DType.kFloat8E4M3)
+        q.amax_reduction_group = dist.group.WORLD
+        # Every value-materialization path must reject it (hash, eq, __fx_repr__).
+        with pytest.raises(TypeError):
+            hash(q)
+        with pytest.raises(TypeError):
+            q.__fx_repr__()
+    finally:
+        if created:
+            dist.destroy_process_group()
+
+
 @pytest.mark.skipif(
     not _opaque_available,
     reason="torch.compile opaque-object support requires PyTorch >= 2.11",

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -505,19 +505,59 @@ def test_value_quantizer_rejects_process_group():
             dist.destroy_process_group()
 
 
+if _opaque_available:
+    # A minimal custom op taking a tensor and a value-opaque quantizer that
+    # quantizes + dequantizes inside it, one per production quantizer class.
+    # ``test_quantizer_value_object_fullgraph`` drives this under
+    # ``torch.compile(fullgraph=True)`` so the quantizer is used *inside* the
+    # graph -- proving the opaque-type registration took effect (a graph break
+    # would make ``fullgraph=True`` raise).
+    _qdq_lib = torch.library.Library("test_te_qdq", "DEF")
+    _QDQ_OPS = {}
+    for _qcls in (
+        MXFP8Quantizer,
+        Float8BlockQuantizer,
+        Float8CurrentScalingQuantizer,
+        NVFP4Quantizer,
+    ):
+        _op = f"qdq_{_qcls.__name__}"
+        _qdq_lib.define(f"{_op}(Tensor x, {get_opaque_type_name(_qcls)} q) -> Tensor")
+
+        @torch.library.impl(f"test_te_qdq::{_op}", "CompositeExplicitAutograd", lib=_qdq_lib)
+        def _qdq_impl(x, q):
+            return q(x).dequantize()
+
+        @torch.library.register_fake(f"test_te_qdq::{_op}", lib=_qdq_lib)
+        def _qdq_fake(x, q):
+            return torch.empty_like(x)
+
+        _QDQ_OPS[_qcls] = getattr(torch.ops.test_te_qdq, _op)
+
+
 @pytest.mark.skipif(
     not _opaque_available,
     reason="torch.compile opaque-object support requires PyTorch >= 2.11",
 )
 @pytest.mark.parametrize("factory, other_kwargs", _VALUE_QUANTIZERS)
 def test_quantizer_value_object_fullgraph(factory, other_kwargs):
-    """Quantizer survives torch.compile(fullgraph=True) - verifies registration took effect."""
+    """Quantizer is usable *inside* a torch.compile(fullgraph=True) graph.
 
-    def fn(quantizer):
-        return quantizer
+    A custom op quantizes+dequantizes with the (opaque value) quantizer; the
+    compiled result must match eager. ``fullgraph=True`` raises on any graph
+    break, so this proves the opaque-type registration actually took effect --
+    unlike merely passing the quantizer through.
+    """
+    q = factory()
+    if not (torch.cuda.is_available() and _hw_available(q)):
+        pytest.skip("format not supported on this HW")
 
+    op = _QDQ_OPS[type(q)]
+    x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+
+    def fn(inp):
+        return op(inp, q)
+
+    ref = fn(x)
     torch._dynamo.reset()
-    compiled = torch.compile(fn, fullgraph=True)
-
-    quantizer = factory()
-    assert compiled(quantizer) is quantizer
+    out = torch.compile(fn, fullgraph=True)(x)
+    torch.testing.assert_close(out, ref, rtol=0.0, atol=0.0)

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -459,3 +459,21 @@ def test_quantizer_value_object(factory, other_kwargs):
     rebuilt = eval(repr_str, dict(globals_))  # pylint: disable=eval-used
     assert rebuilt == a and rebuilt is not a
     assert hash(rebuilt) == hash(a)
+
+
+@pytest.mark.skipif(
+    not _opaque_available,
+    reason="torch.compile opaque-object support requires PyTorch >= 2.11",
+)
+@pytest.mark.parametrize("factory, other_kwargs", _VALUE_QUANTIZERS)
+def test_quantizer_value_object_fullgraph(factory, other_kwargs):
+    """Quantizer survives torch.compile(fullgraph=True) - verifies registration took effect."""
+
+    def fn(quantizer):
+        return quantizer
+
+    torch._dynamo.reset()
+    compiled = torch.compile(fn, fullgraph=True)
+
+    quantizer = factory()
+    assert compiled(quantizer) is quantizer

--- a/transformer_engine/common/ep/ep_api.cpp
+++ b/transformer_engine/common/ep/ep_api.cpp
@@ -13,6 +13,10 @@
 
 #include <transformer_engine/ep.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+
 #include "../util/logging.h"
 
 #if defined(NVTE_WITH_NCCL_EP)
@@ -24,18 +28,30 @@
 
 using transformer_engine::ep::EPBackend;
 
-void nvte_ep_initialize(void* ep_comm, NVTEEpGroupConfig group_config) {
-  NVTE_CHECK(ep_comm != nullptr, "ep_comm must not be null");
-  EPBackend::initialize(static_cast<ncclComm_t>(ep_comm), group_config);
-}
-
-void nvte_ep_shutdown(void) { EPBackend::shutdown(); }
-
-size_t nvte_ep_handle_mem_size(NVTEEpLayerConfig layer_cfg) {
-  return EPBackend::get().handle_mem_size(layer_cfg);
-}
-
 namespace {
+// Smallest accepted struct_size: covers the base (required) fields. Frozen;
+// never raise these. Later fields are read only when struct_size covers them.
+constexpr size_t kGroupConfigMinSize = offsetof(NVTEEpGroupConfig, zero_copy) + sizeof(int);
+constexpr size_t kLayerConfigMinSize =
+    offsetof(NVTEEpLayerConfig, dispatch_output_per_expert_alignment) + sizeof(size_t);
+
+// Copy a caller's versioned config into a full current-layout struct: fields
+// the caller did not provide stay zero, extra trailing fields are dropped.
+// struct_size 0 is read as the base layout. Requires a size_t struct_size
+// first member.
+template <typename Cfg>
+Cfg normalize_ep_config(const Cfg* user, size_t min_size, const char* name) {
+  NVTE_CHECK(user != nullptr, name, " must not be null");
+  const size_t want = (user->struct_size == 0) ? min_size : user->struct_size;
+  NVTE_CHECK(want >= min_size, name, ".struct_size (", user->struct_size,
+             ") is below the required minimum ", min_size,
+             "; zero-initialize the struct or set struct_size via NVTE_EP_*_CONFIG_INIT");
+  Cfg cfg{};
+  std::memcpy(&cfg, user, std::min(want, sizeof(Cfg)));
+  cfg.struct_size = sizeof(Cfg);
+  return cfg;
+}
+
 inline void* handle_mem_ptr(NVTETensor mem) {
   void* p = nvte_tensor_data(mem);
   NVTE_CHECK(p != nullptr, "handle_mem tensor data must not be null");
@@ -43,9 +59,25 @@ inline void* handle_mem_ptr(NVTETensor mem) {
 }
 }  // namespace
 
-void nvte_ep_prepare(NVTETensor handle_mem, NVTETensor topk_idx, NVTETensor token_counts,
-                     NVTEEpLayerConfig layer_cfg, cudaStream_t stream) {
-  EPBackend::get().prepare(handle_mem_ptr(handle_mem), topk_idx, token_counts, layer_cfg, stream);
+void nvte_ep_initialize(void* ep_comm, const NVTEEpGroupConfig* group_config) {
+  NVTE_CHECK(ep_comm != nullptr, "ep_comm must not be null");
+  NVTEEpGroupConfig cfg = normalize_ep_config(group_config, kGroupConfigMinSize, "group_config");
+  EPBackend::initialize(static_cast<ncclComm_t>(ep_comm), cfg);
+}
+
+void nvte_ep_shutdown(void) { EPBackend::shutdown(); }
+
+size_t nvte_ep_handle_mem_size(const NVTEEpLayerConfig* layer_cfg) {
+  NVTEEpLayerConfig cfg = normalize_ep_config(layer_cfg, kLayerConfigMinSize, "layer_cfg");
+  return EPBackend::get().handle_mem_size(cfg);
+}
+
+void nvte_ep_prepare(NVTETensor handle_mem, NVTETensor topk_idx, NVTETensor recv_tokens_per_expert,
+                     NVTETensor total_recv_tokens_per_rank, const NVTEEpLayerConfig* layer_cfg,
+                     cudaStream_t stream) {
+  NVTEEpLayerConfig cfg = normalize_ep_config(layer_cfg, kLayerConfigMinSize, "layer_cfg");
+  EPBackend::get().prepare(handle_mem_ptr(handle_mem), topk_idx, recv_tokens_per_expert,
+                           total_recv_tokens_per_rank, cfg, stream);
 }
 
 void nvte_ep_dispatch(NVTETensor handle_mem, NVTETensor topk_idx, NVTETensor tokens,
@@ -88,15 +120,18 @@ namespace {
 }
 }  // namespace
 
-void nvte_ep_initialize(void* /*ep_comm*/, NVTEEpGroupConfig /*group_config*/) { ep_not_built(); }
+void nvte_ep_initialize(void* /*ep_comm*/, const NVTEEpGroupConfig* /*group_config*/) {
+  ep_not_built();
+}
 
 void nvte_ep_shutdown(void) {}
 
-size_t nvte_ep_handle_mem_size(NVTEEpLayerConfig /*layer_cfg*/) { ep_not_built(); }
+size_t nvte_ep_handle_mem_size(const NVTEEpLayerConfig* /*layer_cfg*/) { ep_not_built(); }
 
 void nvte_ep_prepare(NVTETensor /*handle_mem*/, NVTETensor /*topk_idx*/,
-                     NVTETensor /*token_counts*/, NVTEEpLayerConfig /*layer_cfg*/,
-                     cudaStream_t /*stream*/) {
+                     NVTETensor /*recv_tokens_per_expert*/,
+                     NVTETensor /*total_recv_tokens_per_rank*/,
+                     const NVTEEpLayerConfig* /*layer_cfg*/, cudaStream_t /*stream*/) {
   ep_not_built();
 }
 

--- a/transformer_engine/common/ep/ep_backend.cpp
+++ b/transformer_engine/common/ep/ep_backend.cpp
@@ -110,8 +110,8 @@ void EPBackend::validate_config(const NVTEEpGroupConfig& config) {
              "hidden_dim * sizeof(max_token_dtype) exceeds 4 GiB; got ", row_bytes, " bytes");
   NVTE_CHECK(config.num_experts % config.ep_size == 0, "num_experts (", config.num_experts,
              ") must be divisible by ep_size (", config.ep_size, ")");
-  NVTE_CHECK(config.max_num_sms >= 0, "max_num_sms must be >= 0 (0 = auto), got ",
-             config.max_num_sms);
+  NVTE_CHECK(config.num_comm_sms >= 0, "num_comm_sms must be >= 0 (0 = auto), got ",
+             config.num_comm_sms);
 
   const int sm = cuda::sm_arch();
   NVTE_CHECK(sm >= 90, "NCCL EP requires SM_90+ (Hopper or later), but current device is SM_", sm);
@@ -207,8 +207,8 @@ void EPBackend::init(ncclComm_t ep_comm, NVTEEpGroupConfig group_config) {
   cfg.rdma_buffer_size = NCCL_EP_AUTO;
   cfg.num_qp_per_rank = NCCL_EP_AUTO;
   cfg.num_channels = NCCL_EP_AUTO;
-  cfg.max_num_sms = group_config.max_num_sms > 0
-                        ? static_cast<unsigned int>(group_config.max_num_sms)
+  cfg.max_num_sms = group_config.num_comm_sms > 0
+                        ? static_cast<unsigned int>(group_config.num_comm_sms)
                         : NCCL_EP_AUTO;
   // Must be > 0; NCCL EP errors out on 0.
   cfg.max_recv_tokens_per_rank = static_cast<unsigned int>(group_config.max_recv_tokens_per_rank);
@@ -319,8 +319,11 @@ size_t EPBackend::handle_mem_size(NVTEEpLayerConfig layer_cfg) {
   return hm_size;
 }
 
-void EPBackend::prepare(void* handle_mem, const NVTETensor topk_idx, NVTETensor token_counts,
-                        NVTEEpLayerConfig layer_cfg, cudaStream_t stream) {
+void EPBackend::prepare(void* handle_mem, const NVTETensor topk_idx,
+                        NVTETensor recv_tokens_per_expert,
+                        NVTETensor /*total_recv_tokens_per_rank*/, NVTEEpLayerConfig layer_cfg,
+                        cudaStream_t stream) {
+  // total_recv_tokens_per_rank is a reserved placeholder; not yet populated.
   NVTE_CHECK(handle_mem != nullptr, "handle_mem must not be null");
   NVTE_CHECK(layer_cfg.top_k > 0, "top_k must be > 0, got ", layer_cfg.top_k);
   NVTE_CHECK(nvte_tensor_shape(topk_idx).ndim == 2, "topk_idx must be 2D [T, top_k]");
@@ -329,13 +332,15 @@ void EPBackend::prepare(void* handle_mem, const NVTETensor topk_idx, NVTETensor 
   ncclEpTensor_t nccl_topk_idx = make_nccl_ep_tensor(topk_idx, topk_idx_shape);
 
   // ncclEpUpdateHandle writes per-expert counts via expert_counters.
-  NVTEShape token_counts_shape;
-  ncclEpTensor_t token_counts_desc;
-  if (token_counts != nullptr) {
-    token_counts_desc = make_nccl_ep_tensor(token_counts, token_counts_shape);
+  NVTEShape recv_tokens_per_expert_shape;
+  ncclEpTensor_t recv_tokens_per_expert_desc;
+  if (recv_tokens_per_expert != nullptr) {
+    recv_tokens_per_expert_desc =
+        make_nccl_ep_tensor(recv_tokens_per_expert, recv_tokens_per_expert_shape);
   }
   ncclEpLayoutInfo_t layout_info = NCCL_EP_LAYOUT_INFO_INIT;
-  layout_info.expert_counters = (token_counts != nullptr) ? &token_counts_desc : nullptr;
+  layout_info.expert_counters =
+      (recv_tokens_per_expert != nullptr) ? &recv_tokens_per_expert_desc : nullptr;
 
   std::lock_guard<std::mutex> lock(mutex_);
   NVTE_CHECK(initialized_, "EPBackend not initialized");

--- a/transformer_engine/common/ep/ep_backend.h
+++ b/transformer_engine/common/ep/ep_backend.h
@@ -46,8 +46,9 @@ class EPBackend {
   size_t handle_mem_size(NVTEEpLayerConfig layer_cfg);
 
   // Seeds the cache for handle_mem with layer_cfg and runs the routing AllGather.
-  void prepare(void* handle_mem, const NVTETensor topk_idx, NVTETensor token_counts,
-               NVTEEpLayerConfig layer_cfg, cudaStream_t stream);
+  void prepare(void* handle_mem, const NVTETensor topk_idx, NVTETensor recv_tokens_per_expert,
+               NVTETensor total_recv_tokens_per_rank, NVTEEpLayerConfig layer_cfg,
+               cudaStream_t stream);
 
   // Per-step ops below require a prior prepare().
   void dispatch(void* handle_mem, const NVTETensor topk_idx, const NVTETensor tokens,

--- a/transformer_engine/common/include/transformer_engine/ep.h
+++ b/transformer_engine/common/include/transformer_engine/ep.h
@@ -28,11 +28,16 @@ extern "C" {
 #endif
 
 /* -- Config structs ------------------------------------------------------- */
-/* TODO: add a struct_size/version field to these configs (and align with other
- *       TE public structs) once a TE-wide convention for ABI versioning lands. */
+/* Each config begins with struct_size so the API can add fields without
+ * breaking ABI. The backend reads only the bytes struct_size covers and
+ * zero-defaults the rest; struct_size 0 means the base layout. Append new
+ * fields at the end only; never reorder, resize, or remove existing ones. */
 
 /*! \brief Group-level EP configuration (fixed for the EP group lifetime). */
 typedef struct {
+  /*! Struct size in bytes, or 0 for the base layout. Set to
+   *  sizeof(NVTEEpGroupConfig) to include fields added in newer versions. */
+  size_t struct_size;
   /*! EP world size. */
   int ep_size;
   /*! Total experts across all ranks. */
@@ -43,10 +48,11 @@ typedef struct {
   int max_recv_tokens_per_rank;
   /*! Token hidden dimension. */
   int hidden_dim;
-  /*! Max SMs for EP kernels. 0 = auto. */
-  int max_num_sms;
+  /*! Max SMs for NCCL EP dispatch/combine kernels. 0 = auto. */
+  int num_comm_sms;
   /*! Widest token dtype the group will dispatch; sizes staging buffers.
-   *  Per-dispatch tensors may use any dtype with element size <= this. */
+   *  Required (no default): must be set to a real token dtype. Per-dispatch
+   *  tensors may use any dtype with element size <= this. */
   NVTEDType max_token_dtype;
   /*! Zero-copy dispatch/combine. When nonzero, payload tensors must be backed
    *  by NVTECommWindow handles and transfer in place (no staging copies);
@@ -59,6 +65,9 @@ typedef struct {
  *         overflow policy, ...).
  */
 typedef struct {
+  /*! Struct size in bytes, or 0 for the base layout. Set to
+   *  sizeof(NVTEEpLayerConfig) to include fields added in newer versions. */
+  size_t struct_size;
   /*! Per-token expert fan-out (> 0). */
   int top_k;
   /*! Per-expert recv-slab alignment in tokens (power of two; 0/1 disables).
@@ -66,6 +75,12 @@ typedef struct {
    *  multiple of this for downstream per-expert GEMM alignment. */
   size_t dispatch_output_per_expert_alignment;
 } NVTEEpLayerConfig;
+
+/* Zero-init a config with struct_size set to the current layout:
+ *   NVTEEpGroupConfig cfg = NVTE_EP_GROUP_CONFIG_INIT;
+ *   cfg.ep_size = ...; */
+#define NVTE_EP_GROUP_CONFIG_INIT {sizeof(NVTEEpGroupConfig)}
+#define NVTE_EP_LAYER_CONFIG_INIT {sizeof(NVTEEpLayerConfig)}
 
 /* -- Bootstrap ------------------------------------------------------------ */
 
@@ -78,9 +93,9 @@ typedef struct {
  *  group per process, bound to the current CUDA device.
  *
  *  \param[in] ep_comm      Opaque ncclComm_t for the EP sub-group.
- *  \param[in] group_config Group-level EP configuration.
+ *  \param[in] group_config Group-level EP configuration (struct_size set).
  */
-void nvte_ep_initialize(void* ep_comm, NVTEEpGroupConfig group_config);
+void nvte_ep_initialize(void* ep_comm, const NVTEEpGroupConfig* group_config);
 
 /*! \brief Tear down the EP backend. Idempotent. Does not destroy ep_comm. */
 void nvte_ep_shutdown(void);
@@ -94,10 +109,10 @@ void nvte_ep_shutdown(void);
  *  for that layer (the backend keys its cache on the pointer). Host-only;
  *  size is stable for a given (group, layer) pair.
  *
- *  \param[in] layer_cfg  Per-call layer configuration.
+ *  \param[in] layer_cfg  Per-call layer configuration (struct_size set).
  *  \return size in bytes for the handle_mem buffer.
  */
-size_t nvte_ep_handle_mem_size(NVTEEpLayerConfig layer_cfg);
+size_t nvte_ep_handle_mem_size(const NVTEEpLayerConfig* layer_cfg);
 
 /* -- Per-step ops (all allocation-free, CUDA graph-capturable) ------------ */
 
@@ -106,17 +121,19 @@ size_t nvte_ep_handle_mem_size(NVTEEpLayerConfig layer_cfg);
  *  AllGathers topk_idx across the EP group and stages per-expert offsets and
  *  counts into handle_mem so the matching dispatch/combine/_bwd can run with
  *  no further routing computation. Must precede every dispatch/combine/_bwd
- *  that uses this handle_mem. token_counts becomes host-valid after a stream
- *  sync.
+ *  that uses this handle_mem. recv_tokens_per_expert becomes host-valid after a
+ *  stream sync.
  *
- *  \param[in]     handle_mem    uint8 routing-state buffer.
- *  \param[in]     topk_idx      [T, top_k] int64 routing indices.
- *  \param[out]    token_counts  [num_local_experts] int32 counts.
- *  \param[in]     layer_cfg     Per-call layer configuration.
- *  \param[in]     stream        CUDA stream.
+ *  \param[in]     handle_mem                 uint8 routing-state buffer.
+ *  \param[in]     topk_idx                   [T, top_k] int64 routing indices.
+ *  \param[out]    recv_tokens_per_expert     [num_local_experts] int32 counts.
+ *  \param[out]    total_recv_tokens_per_rank Reserved placeholder; may be null. Unused for now.
+ *  \param[in]     layer_cfg                  Per-call layer configuration (struct_size set).
+ *  \param[in]     stream                     CUDA stream.
  */
-void nvte_ep_prepare(NVTETensor handle_mem, NVTETensor topk_idx, NVTETensor token_counts,
-                     NVTEEpLayerConfig layer_cfg, cudaStream_t stream);
+void nvte_ep_prepare(NVTETensor handle_mem, NVTETensor topk_idx, NVTETensor recv_tokens_per_expert,
+                     NVTETensor total_recv_tokens_per_rank, const NVTEEpLayerConfig* layer_cfg,
+                     cudaStream_t stream);
 
 /*! \brief Dispatch tokens (and routing weights) to expert ranks.
  *

--- a/transformer_engine/jax/csrc/extensions/ep.cpp
+++ b/transformer_engine/jax/csrc/extensions/ep.cpp
@@ -45,16 +45,17 @@ class EpResources {
     NVTE_CHECK_NCCL(ncclCommInitRank(&comm_, p.ep_size, uid, p.rank_within_group));
     // zero_copy=0: JAX EP path always stages payloads; the zero-copy fast path
     // requires NVTECommWindow-backed tensors, which JAX bindings don't expose.
-    NVTEEpGroupConfig cfg{.ep_size = p.ep_size,
+    NVTEEpGroupConfig cfg{.struct_size = sizeof(NVTEEpGroupConfig),
+                          .ep_size = p.ep_size,
                           .num_experts = p.num_experts,
                           .max_tokens_per_rank = p.max_tokens_per_rank,
                           .max_recv_tokens_per_rank = p.max_recv_tokens_per_rank,
                           .hidden_dim = p.hidden_dim,
-                          .max_num_sms = p.max_num_sms,
+                          .num_comm_sms = p.max_num_sms,
                           .max_token_dtype = p.max_token_dtype,
                           .zero_copy = 0};
     try {
-      nvte_ep_initialize(static_cast<void*>(comm_), cfg);
+      nvte_ep_initialize(static_cast<void*>(comm_), &cfg);
     } catch (...) {
       ncclCommDestroy(comm_);
       comm_ = nullptr;
@@ -162,8 +163,11 @@ void ReleaseEpResources() {
 }
 
 size_t EpHandleMemSize(int top_k, size_t dispatch_output_per_expert_alignment) {
-  NVTEEpLayerConfig layer_cfg{top_k, dispatch_output_per_expert_alignment};
-  return nvte_ep_handle_mem_size(layer_cfg);
+  NVTEEpLayerConfig layer_cfg{
+      .struct_size = sizeof(NVTEEpLayerConfig),
+      .top_k = top_k,
+      .dispatch_output_per_expert_alignment = dispatch_output_per_expert_alignment};
+  return nvte_ep_handle_mem_size(&layer_cfg);
 }
 
 pybind11::capsule GetEpInstanceStateTypeIdCapsule() {
@@ -192,8 +196,8 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(EpInstantiateHandler, EpInstantiateImpl, FFI::Bind
 // ── ep_prepare ────────────────────────────────────────────────────────────────
 
 Error_Type EpPrepareFFI(cudaStream_t stream, EpInstanceState* ep_state, Buffer_Type topk_idx,
-                        Result_Type token_counts, Result_Type handle_mem, Result_Type workspace,
-                        EpConfig config) {
+                        Result_Type recv_tokens_per_expert, Result_Type handle_mem,
+                        Result_Type workspace, EpConfig config) {
   (void)ep_state;  // lifetime only.
   auto topk_dims = topk_idx.dimensions();
   NVTE_CHECK(topk_dims.size() >= 2,
@@ -218,15 +222,19 @@ Error_Type EpPrepareFFI(cudaStream_t stream, EpInstanceState* ep_state, Buffer_T
   }
   auto topk_idx_ = TensorWrapper(topk_idx_data, topk_shape, DType::kInt64);
 
-  std::vector<size_t> tc_shape = {static_cast<size_t>(token_counts->element_count())};
-  auto token_counts_ = TensorWrapper(token_counts->untyped_data(), tc_shape, DType::kInt32);
+  std::vector<size_t> tc_shape = {static_cast<size_t>(recv_tokens_per_expert->element_count())};
+  auto recv_tokens_per_expert_ =
+      TensorWrapper(recv_tokens_per_expert->untyped_data(), tc_shape, DType::kInt32);
 
   std::vector<size_t> hm_shape = {static_cast<size_t>(handle_mem->element_count())};
   auto handle_mem_ = TensorWrapper(handle_mem->untyped_data(), hm_shape, DType::kByte);
 
-  NVTEEpLayerConfig layer_cfg{static_cast<int>(config.top_k),
-                              static_cast<size_t>(config.dispatch_output_per_expert_alignment)};
-  nvte_ep_prepare(handle_mem_.data(), topk_idx_.data(), token_counts_.data(), layer_cfg, stream);
+  NVTEEpLayerConfig layer_cfg{.struct_size = sizeof(NVTEEpLayerConfig),
+                              .top_k = static_cast<int>(config.top_k),
+                              .dispatch_output_per_expert_alignment =
+                                  static_cast<size_t>(config.dispatch_output_per_expert_alignment)};
+  nvte_ep_prepare(handle_mem_.data(), topk_idx_.data(), recv_tokens_per_expert_.data(),
+                  /*total_recv_tokens_per_rank=*/nullptr, &layer_cfg, stream);
   return ffi_with_cuda_error_check();
 }
 
@@ -235,8 +243,8 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(EpPrepareHandler, EpPrepareFFI,
                                   .Ctx<FFI_Stream_Type>()                     // stream
                                   .Ctx<::xla::ffi::State<EpInstanceState>>()  // EP state
                                   .Arg<Buffer_Type>()                         // topk_idx
-                                  .Ret<Buffer_Type>()                         // token_counts
-                                  .Ret<Buffer_Type>()                         // handle_mem
+                                  .Ret<Buffer_Type>()  // recv_tokens_per_expert
+                                  .Ret<Buffer_Type>()  // handle_mem
                                   .Ret<Buffer_Type>()  // workspace (FFI scratch)
                                   .Attrs<EpConfig>(),
                               FFI_CudaGraph_Traits);

--- a/transformer_engine/pytorch/csrc/extensions.h
+++ b/transformer_engine/pytorch/csrc/extensions.h
@@ -9,6 +9,7 @@
 
 #include <nccl.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -660,6 +661,42 @@ void inplace_multi_tensor_swizzle_scales_for_gemm_unchecked(std::vector<py::obje
                                                             bool columnwise_usage);
 
 void grouped_swizzle_for_gemm(py::handle &tensor, bool rowwise, bool columnwise);
+
+/***************************************************************************************************
+ * Expert Parallelism
+ **************************************************************************************************/
+
+// Borrows torch's NCCL host comm (``comm_ptr`` from ``ProcessGroupNCCL._comm_ptr()``).
+// ``group_name`` is the PG name used by the symm-mem window resolver.
+// ``zero_copy`` is forwarded into ``NVTEEpGroupConfig.zero_copy``.
+void ep_initialize(uintptr_t comm_ptr, const std::string &group_name, int64_t num_experts,
+                   int64_t max_tokens_per_rank, int64_t max_recv_tokens_per_rank,
+                   int64_t hidden_dim, int64_t max_num_sms, pybind11::object max_token_dtype,
+                   bool zero_copy);
+
+void ep_finalize();
+
+// Returns the zero-copy mode captured at ep_initialize.
+bool ep_get_zero_copy();
+
+// Returns the handle_mem byte size for the given layer config.
+int64_t ep_handle_mem_size(int64_t top_k, int64_t dispatch_output_per_expert_alignment);
+
+void ep_prepare(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor token_counts, int64_t top_k,
+                int64_t dispatch_output_per_expert_alignment);
+
+void ep_dispatch(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor tokens,
+                 at::Tensor topk_weights, at::Tensor recv_tokens, at::Tensor recv_topk_weights);
+
+void ep_combine(at::Tensor handle_mem, at::Tensor expert_out, at::Tensor result);
+
+void ep_dispatch_bwd(at::Tensor handle_mem, at::Tensor grad, at::Tensor g_recv_topk_weights,
+                     at::Tensor grad_tokens, at::Tensor grad_topk_weights);
+
+void ep_combine_bwd(at::Tensor handle_mem, at::Tensor grad, at::Tensor grad_expert_out);
+
+// Registers the EP pybind functions on `m`. Defined under NVTE_WITH_NCCL_EP.
+void register_ep_bindings(pybind11::module_ &m);
 
 /***************************************************************************************************
  * NVSHMEM APIs

--- a/transformer_engine/pytorch/csrc/extensions/ep.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/ep.cpp
@@ -136,16 +136,17 @@ void ep_initialize(uintptr_t comm_ptr, const std::string& group_name, int64_t nu
   NVTE_CHECK(ncclCommCount(ep_comm, &ep_size) == ncclSuccess, "ncclCommCount failed");
   auto torch_dtype = max_token_dtype.cast<at::ScalarType>();
   NVTEEpGroupConfig cfg{
-      /*ep_size=*/ep_size,
-      /*num_experts=*/static_cast<int>(num_experts),
-      /*max_tokens_per_rank=*/static_cast<int>(max_tokens_per_rank),
-      /*max_recv_tokens_per_rank=*/static_cast<int>(max_recv_tokens_per_rank),
-      /*hidden_dim=*/static_cast<int>(hidden_dim),
-      /*max_num_sms=*/static_cast<int>(max_num_sms),
-      /*max_token_dtype=*/static_cast<NVTEDType>(GetTransformerEngineDType(torch_dtype)),
-      /*zero_copy=*/zero_copy ? 1 : 0,
+      .struct_size = sizeof(NVTEEpGroupConfig),
+      .ep_size = ep_size,
+      .num_experts = static_cast<int>(num_experts),
+      .max_tokens_per_rank = static_cast<int>(max_tokens_per_rank),
+      .max_recv_tokens_per_rank = static_cast<int>(max_recv_tokens_per_rank),
+      .hidden_dim = static_cast<int>(hidden_dim),
+      .num_comm_sms = static_cast<int>(max_num_sms),
+      .max_token_dtype = static_cast<NVTEDType>(GetTransformerEngineDType(torch_dtype)),
+      .zero_copy = zero_copy ? 1 : 0,
   };
-  nvte_ep_initialize(static_cast<void*>(ep_comm), cfg);
+  nvte_ep_initialize(static_cast<void*>(ep_comm), &cfg);
   g_zero_copy_enabled.store(zero_copy, std::memory_order_relaxed);
   g_ep_initialized = true;
   g_ep_group_name = group_name;
@@ -164,17 +165,18 @@ namespace {
 
 NVTEEpLayerConfig make_layer_cfg(int64_t top_k, int64_t dispatch_output_per_expert_alignment) {
   return NVTEEpLayerConfig{
-      /*top_k=*/static_cast<int>(top_k),
-      /*dispatch_output_per_expert_alignment=*/
-      static_cast<size_t>(dispatch_output_per_expert_alignment),
+      .struct_size = sizeof(NVTEEpLayerConfig),
+      .top_k = static_cast<int>(top_k),
+      .dispatch_output_per_expert_alignment =
+          static_cast<size_t>(dispatch_output_per_expert_alignment),
   };
 }
 
 }  // namespace
 
 int64_t ep_handle_mem_size(int64_t top_k, int64_t dispatch_output_per_expert_alignment) {
-  return static_cast<int64_t>(
-      nvte_ep_handle_mem_size(make_layer_cfg(top_k, dispatch_output_per_expert_alignment)));
+  auto layer_cfg = make_layer_cfg(top_k, dispatch_output_per_expert_alignment);
+  return static_cast<int64_t>(nvte_ep_handle_mem_size(&layer_cfg));
 }
 
 // ── Per-step ops ─────────────────────────────────────────────────────────────
@@ -194,8 +196,9 @@ void ep_prepare(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor token_cou
   auto handle_mem_te = makeTransformerEngineTensor(
       handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
 
+  auto layer_cfg = make_layer_cfg(top_k, dispatch_output_per_expert_alignment);
   nvte_ep_prepare(handle_mem_te.data(), topk_idx_te.data(), token_counts_te.data(),
-                  make_layer_cfg(top_k, dispatch_output_per_expert_alignment), stream);
+                  /*total_recv_tokens_per_rank=*/nullptr, &layer_cfg, stream);
 }
 
 void ep_dispatch(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor tokens,

--- a/transformer_engine/pytorch/csrc/extensions/ep.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/ep.cpp
@@ -1,0 +1,386 @@
+/*************************************************************************
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See LICENSE for license information.
+ ************************************************************************/
+
+#ifdef NVTE_WITH_NCCL_EP
+
+#include "transformer_engine/ep.h"
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAStream.h>
+#include <nccl.h>
+#include <torch/extension.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+#include <tuple>
+#include <vector>
+
+#include "transformer_engine/comm_window.h"
+
+#ifdef NCCL_HAS_SYMMEM_SUPPORT
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#endif
+
+#include "../common.h"
+#include "../extensions.h"
+#include "transformer_engine/gemm.h"
+
+namespace transformer_engine::pytorch {
+
+namespace {
+
+// EP process group name, captured at ep_initialize. Used by the symm-mem
+// window resolver below to look up SymmetricMemory for payload tensors.
+// Empty until ep_initialize.
+std::string g_ep_group_name;  // NOLINT(runtime/string)
+
+// True while the EP backend holds a borrowed reference to torch's NCCL comm.
+bool g_ep_initialized = false;
+
+// Zero-copy IO toggle captured at ep_initialize. Atomic so the Python-side
+// toggle is safe against concurrent ep_dispatch/combine (which release the GIL).
+std::atomic<bool> g_zero_copy_enabled{false};
+
+// Sentinel returned by maybe_make_window when zero-copy is off or the tensor
+// is not symm-mem-backed; the backend treats it as "no window, use staged copy".
+constexpr NVTECommWindow kNoWindow = {nullptr, 0};
+
+// Resolve ``t`` to an NCCL symm-mem window for the zero-copy one-sided path.
+// Returns ``kNoWindow`` when symm-mem support isn't compiled in, zero-copy is
+// disabled, no group is set, or ``t`` isn't symm-mem-backed; callers pass the
+// resulting window unconditionally to the backend.
+NVTECommWindow maybe_make_window(const at::Tensor& t) {
+#ifdef NCCL_HAS_SYMMEM_SUPPORT
+  if (!g_zero_copy_enabled.load(std::memory_order_relaxed)) return kNoWindow;
+  if (g_ep_group_name.empty()) return kNoWindow;
+  c10::intrusive_ptr<c10d::symmetric_memory::SymmetricMemory> sm;
+  try {
+    sm = c10d::symmetric_memory::rendezvous(t, g_ep_group_name);
+  } catch (const std::exception&) {
+    return kNoWindow;  // Tensor not symm-mem-backed; fall back to staged copy.
+  }
+  if (sm == nullptr) return kNoWindow;
+  auto* nccl_sm = dynamic_cast<c10d::symmetric_memory::NCCLSymmetricMemory*>(sm.get());
+  NVTE_CHECK(nccl_sm != nullptr,
+             "Symm-mem backend mismatch: expected NCCLSymmetricMemory. Set the backend to "
+             "\"NCCL\" before allocating EP payload buffers.");
+  return NVTECommWindow{static_cast<ncclWindow_t>(nccl_sm->get_window()),
+                        static_cast<uint64_t>(nccl_sm->get_offset())};
+#else
+  (void)t;
+  return kNoWindow;
+#endif
+}
+
+// When zero-copy is enabled, the named tensor must be symm-mem-backed on the
+// EP group. Throws a clear error otherwise. No-op when zero-copy is off or
+// symm-mem support isn't compiled in. Mirrors maybe_make_window's resolution
+// path but turns the "not symm-mem" outcome into a hard error.
+void check_symm_mem_required(const at::Tensor& t, const char* name) {
+#ifdef NCCL_HAS_SYMMEM_SUPPORT
+  if (!g_zero_copy_enabled.load(std::memory_order_relaxed)) return;
+  NVTE_CHECK(!g_ep_group_name.empty(),
+             "Zero-copy is enabled but EP group name is unset; call ep_initialize first.");
+  c10::intrusive_ptr<c10d::symmetric_memory::SymmetricMemory> sm;
+  try {
+    sm = c10d::symmetric_memory::rendezvous(t, g_ep_group_name);
+  } catch (const std::exception&) {
+    sm = nullptr;
+  }
+  NVTE_CHECK(sm != nullptr, "ep zero-copy: ", name,
+             " must be symm-mem-backed on the EP group (allocate via symm_mem_alloc).");
+#else
+  (void)t;
+  (void)name;
+#endif
+}
+
+// The backend only accepts int64 topk_idx. The PyTorch wrapper enforces this
+// at the boundary so the per-step ops don't need an upcast workspace.
+void check_topk_idx_int64(at::Tensor topk_idx) {
+  NVTE_CHECK(topk_idx.is_contiguous(), "topk_idx must be contiguous");
+  NVTE_CHECK(topk_idx.scalar_type() == at::kLong,
+             "topk_idx must be int64; got dtype=", c10::toString(topk_idx.scalar_type()),
+             ". Cast with topk_idx.long() before calling.");
+}
+
+using Shape = std::vector<size_t>;
+
+}  // namespace
+
+bool ep_get_zero_copy() { return g_zero_copy_enabled.load(std::memory_order_relaxed); }
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+// Borrows torch's NCCL host comm (from ``ProcessGroupNCCL._comm_ptr()``).
+// ``group_name`` is captured for the symm-mem window resolver.
+
+void ep_initialize(uintptr_t comm_ptr, const std::string& group_name, int64_t num_experts,
+                   int64_t max_tokens_per_rank, int64_t max_recv_tokens_per_rank,
+                   int64_t hidden_dim, int64_t max_num_sms, pybind11::object max_token_dtype,
+                   bool zero_copy) {
+  NVTE_CHECK(!group_name.empty(), "group_name must be non-empty (used for symm-mem lookup)");
+  NVTE_CHECK(comm_ptr != 0, "comm_ptr must be non-null (torch NCCL host comm pointer)");
+  NVTE_CHECK(!g_ep_initialized, "ep_initialize called twice without ep_finalize");
+
+  auto ep_comm = reinterpret_cast<ncclComm_t>(comm_ptr);
+  int ep_size = 0;
+  NVTE_CHECK(ncclCommCount(ep_comm, &ep_size) == ncclSuccess, "ncclCommCount failed");
+  auto torch_dtype = max_token_dtype.cast<at::ScalarType>();
+  NVTEEpGroupConfig cfg{
+      /*ep_size=*/ep_size,
+      /*num_experts=*/static_cast<int>(num_experts),
+      /*max_tokens_per_rank=*/static_cast<int>(max_tokens_per_rank),
+      /*max_recv_tokens_per_rank=*/static_cast<int>(max_recv_tokens_per_rank),
+      /*hidden_dim=*/static_cast<int>(hidden_dim),
+      /*max_num_sms=*/static_cast<int>(max_num_sms),
+      /*max_token_dtype=*/static_cast<NVTEDType>(GetTransformerEngineDType(torch_dtype)),
+      /*zero_copy=*/zero_copy ? 1 : 0,
+  };
+  nvte_ep_initialize(static_cast<void*>(ep_comm), cfg);
+  g_zero_copy_enabled.store(zero_copy, std::memory_order_relaxed);
+  g_ep_initialized = true;
+  g_ep_group_name = group_name;
+}
+
+void ep_finalize() {
+  if (!g_ep_initialized) return;
+  // The borrowed comm is owned by torch's symm-mem layer; don't destroy it.
+  nvte_ep_shutdown();
+  g_ep_initialized = false;
+  g_ep_group_name.clear();
+  g_zero_copy_enabled.store(false, std::memory_order_relaxed);
+}
+
+namespace {
+
+NVTEEpLayerConfig make_layer_cfg(int64_t top_k, int64_t dispatch_output_per_expert_alignment) {
+  return NVTEEpLayerConfig{
+      /*top_k=*/static_cast<int>(top_k),
+      /*dispatch_output_per_expert_alignment=*/
+      static_cast<size_t>(dispatch_output_per_expert_alignment),
+  };
+}
+
+}  // namespace
+
+int64_t ep_handle_mem_size(int64_t top_k, int64_t dispatch_output_per_expert_alignment) {
+  return static_cast<int64_t>(
+      nvte_ep_handle_mem_size(make_layer_cfg(top_k, dispatch_output_per_expert_alignment)));
+}
+
+// ── Per-step ops ─────────────────────────────────────────────────────────────
+
+void ep_prepare(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor token_counts, int64_t top_k,
+                int64_t dispatch_output_per_expert_alignment) {
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  NVTE_CHECK(topk_idx.dim() >= 2, "topk_idx must be at least 2D [..., top_k]");
+  check_topk_idx_int64(topk_idx);
+  const size_t T_flat = topk_idx.numel() / topk_idx.size(-1);
+  const size_t topk_n = static_cast<size_t>(topk_idx.size(-1));
+
+  auto topk_idx_te =
+      makeTransformerEngineTensor(topk_idx.data_ptr(), Shape{T_flat, topk_n}, DType::kInt64);
+  auto token_counts_te = makeTransformerEngineTensor(
+      token_counts.data_ptr(), Shape{static_cast<size_t>(token_counts.numel())}, DType::kInt32);
+  auto handle_mem_te = makeTransformerEngineTensor(
+      handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
+
+  nvte_ep_prepare(handle_mem_te.data(), topk_idx_te.data(), token_counts_te.data(),
+                  make_layer_cfg(top_k, dispatch_output_per_expert_alignment), stream);
+}
+
+void ep_dispatch(at::Tensor handle_mem, at::Tensor topk_idx, at::Tensor tokens,
+                 at::Tensor topk_weights, at::Tensor recv_tokens, at::Tensor recv_topk_weights) {
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  NVTE_CHECK(tokens.dim() >= 2, "tokens must be at least 2D [..., H]");
+  NVTE_CHECK(topk_idx.dim() >= 2, "topk_idx must be at least 2D [..., top_k]");
+  NVTE_CHECK(topk_weights.dim() >= 2, "topk_weights must be at least 2D [..., top_k]");
+  NVTE_CHECK(recv_tokens.dim() >= 2, "recv_tokens must be at least 2D [..., recv_pr, H]");
+  check_topk_idx_int64(topk_idx);
+  NVTE_CHECK(tokens.is_contiguous(), "tokens must be contiguous");
+  NVTE_CHECK(topk_weights.is_contiguous(), "topk_weights must be contiguous");
+  NVTE_CHECK(recv_tokens.is_contiguous(), "recv_tokens must be contiguous");
+  NVTE_CHECK(recv_topk_weights.is_contiguous(), "recv_topk_weights must be contiguous");
+
+  const size_t H = static_cast<size_t>(tokens.size(-1));
+  const size_t T_flat = tokens.numel() / H;
+  const size_t topk_n = static_cast<size_t>(topk_idx.size(-1));
+  const size_t recv_pr = recv_tokens.numel() / H;
+
+  NVTE_CHECK(static_cast<size_t>(topk_weights.size(-1)) == topk_n,
+             "topk_weights last dim must equal topk_idx last dim");
+  NVTE_CHECK(static_cast<size_t>(topk_idx.numel()) == T_flat * topk_n,
+             "topk_idx token count must equal tokens token count");
+  NVTE_CHECK(static_cast<size_t>(topk_weights.numel()) == T_flat * topk_n,
+             "topk_weights token count must equal tokens token count");
+  NVTE_CHECK(static_cast<size_t>(recv_topk_weights.numel()) == recv_pr,
+             "recv_topk_weights total size must equal recv_tokens recv_pr");
+  NVTE_CHECK(recv_tokens.scalar_type() == tokens.scalar_type(), "recv_tokens dtype (",
+             c10::toString(recv_tokens.scalar_type()), ") must match tokens dtype (",
+             c10::toString(tokens.scalar_type()), ")");
+  check_symm_mem_required(recv_tokens, "recv_tokens");
+  check_symm_mem_required(recv_topk_weights, "recv_topk_weights");
+
+  auto tok_dtype = GetTransformerEngineDType(tokens.scalar_type());
+  auto handle_mem_te = makeTransformerEngineTensor(
+      handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
+  auto topk_idx_te =
+      makeTransformerEngineTensor(topk_idx.data_ptr(), Shape{T_flat, topk_n}, DType::kInt64);
+  auto tokens_te = makeTransformerEngineTensor(tokens.data_ptr(), Shape{T_flat, H}, tok_dtype);
+  auto topk_w_te =
+      makeTransformerEngineTensor(topk_weights.data_ptr(), Shape{T_flat, topk_n}, DType::kFloat32);
+  auto recv_tokens_te =
+      makeTransformerEngineTensor(recv_tokens.data_ptr(), Shape{recv_pr, H}, tok_dtype);
+  auto recv_topk_w_te =
+      makeTransformerEngineTensor(recv_topk_weights.data_ptr(), Shape{recv_pr}, DType::kFloat32);
+
+  // top_k / alignment are carried by the cached layer_cfg seeded at ep_prepare;
+  // per-step ops look them up by handle_mem pointer in the backend.
+  NVTECommWindow tokens_win = maybe_make_window(tokens);
+  NVTECommWindow topk_w_win = maybe_make_window(topk_weights);
+  NVTECommWindow recv_tokens_win = maybe_make_window(recv_tokens);
+  NVTECommWindow recv_topk_w_win = maybe_make_window(recv_topk_weights);
+  nvte_ep_dispatch(handle_mem_te.data(), topk_idx_te.data(), tokens_te.data(), tokens_win,
+                   topk_w_te.data(), topk_w_win, recv_tokens_te.data(), recv_tokens_win,
+                   recv_topk_w_te.data(), recv_topk_w_win, stream);
+}
+
+void ep_combine(at::Tensor handle_mem, at::Tensor expert_out, at::Tensor result) {
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  NVTE_CHECK(expert_out.dim() >= 2, "expert_out must be at least 2D [..., recv_pr, H]");
+  NVTE_CHECK(result.dim() >= 2, "result must be at least 2D [..., H]");
+  NVTE_CHECK(expert_out.is_contiguous(), "expert_out must be contiguous");
+
+  const size_t H = static_cast<size_t>(expert_out.size(-1));
+  const size_t recv_pr = expert_out.numel() / H;
+  const size_t T_flat = result.numel() / H;
+  NVTE_CHECK(static_cast<size_t>(result.size(-1)) == H,
+             "result hidden dim must equal expert_out hidden dim");
+  NVTE_CHECK(result.scalar_type() == expert_out.scalar_type(), "result dtype (",
+             c10::toString(result.scalar_type()), ") must match expert_out dtype (",
+             c10::toString(expert_out.scalar_type()), ")");
+  check_symm_mem_required(expert_out, "expert_out");
+
+  auto eo_dtype = GetTransformerEngineDType(expert_out.scalar_type());
+  auto handle_mem_te = makeTransformerEngineTensor(
+      handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
+  auto expert_out_te =
+      makeTransformerEngineTensor(expert_out.data_ptr(), Shape{recv_pr, H}, eo_dtype);
+  auto result_te = makeTransformerEngineTensor(result.data_ptr(), Shape{T_flat, H}, eo_dtype);
+
+  NVTECommWindow expert_out_win = maybe_make_window(expert_out);
+  nvte_ep_combine(handle_mem_te.data(), expert_out_te.data(), expert_out_win, result_te.data(),
+                  stream);
+}
+
+void ep_dispatch_bwd(at::Tensor handle_mem, at::Tensor grad, at::Tensor g_recv_topk_weights,
+                     at::Tensor grad_tokens, at::Tensor grad_topk_weights) {
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  NVTE_CHECK(grad.dim() >= 2, "grad must be at least 2D [..., recv_pr, H]");
+  NVTE_CHECK(grad_tokens.dim() >= 2, "grad_tokens must be at least 2D [..., H]");
+  NVTE_CHECK(grad_topk_weights.dim() >= 2, "grad_topk_weights must be at least 2D [..., top_k]");
+  NVTE_CHECK(grad.is_contiguous(), "grad must be contiguous");
+  NVTE_CHECK(g_recv_topk_weights.is_contiguous(), "g_recv_topk_weights must be contiguous");
+
+  const size_t H = static_cast<size_t>(grad.size(-1));
+  const size_t recv_pr = grad.numel() / H;
+  const size_t T_flat = grad_tokens.numel() / H;
+  const size_t topk_n = static_cast<size_t>(grad_topk_weights.size(-1));
+  NVTE_CHECK(static_cast<size_t>(g_recv_topk_weights.numel()) == recv_pr,
+             "g_recv_topk_weights total size must equal grad recv_pr");
+  NVTE_CHECK(static_cast<size_t>(grad_tokens.size(-1)) == H,
+             "grad_tokens hidden dim must equal grad H");
+  NVTE_CHECK(static_cast<size_t>(grad_topk_weights.numel()) == T_flat * topk_n,
+             "grad_topk_weights numel (", grad_topk_weights.numel(),
+             ") must equal T_flat * top_k (", T_flat * topk_n, ")");
+  NVTE_CHECK(grad_tokens.scalar_type() == grad.scalar_type(), "grad_tokens dtype (",
+             c10::toString(grad_tokens.scalar_type()), ") must match grad dtype (",
+             c10::toString(grad.scalar_type()), ")");
+  // Upstream grads are autograd-allocated, so they take the staged-copy path.
+
+  auto g_dtype = GetTransformerEngineDType(grad.scalar_type());
+  auto handle_mem_te = makeTransformerEngineTensor(
+      handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
+  auto grad_te = makeTransformerEngineTensor(grad.data_ptr(), Shape{recv_pr, H}, g_dtype);
+  auto g_recv_w_te =
+      makeTransformerEngineTensor(g_recv_topk_weights.data_ptr(), Shape{recv_pr}, DType::kFloat32);
+  auto grad_tokens_te =
+      makeTransformerEngineTensor(grad_tokens.data_ptr(), Shape{T_flat, H}, g_dtype);
+  auto grad_topk_w_te = makeTransformerEngineTensor(grad_topk_weights.data_ptr(),
+                                                    Shape{T_flat, topk_n}, DType::kFloat32);
+
+  NVTECommWindow grad_win = maybe_make_window(grad);
+  NVTECommWindow g_recv_w_win = maybe_make_window(g_recv_topk_weights);
+  nvte_ep_dispatch_bwd(handle_mem_te.data(), grad_te.data(), grad_win, g_recv_w_te.data(),
+                       g_recv_w_win, grad_tokens_te.data(), grad_topk_w_te.data(), stream);
+}
+
+void ep_combine_bwd(at::Tensor handle_mem, at::Tensor grad, at::Tensor grad_expert_out) {
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  NVTE_CHECK(grad.dim() >= 2, "grad must be at least 2D [..., H]");
+  NVTE_CHECK(grad_expert_out.dim() >= 2, "grad_expert_out must be at least 2D [..., recv_pr, H]");
+  NVTE_CHECK(grad.is_contiguous(), "grad must be contiguous");
+  NVTE_CHECK(grad_expert_out.is_contiguous(), "grad_expert_out must be contiguous");
+
+  const size_t H = static_cast<size_t>(grad.size(-1));
+  const size_t T_flat = grad.numel() / H;
+  const size_t recv_pr = grad_expert_out.numel() / H;
+  NVTE_CHECK(static_cast<size_t>(grad_expert_out.size(-1)) == H,
+             "grad_expert_out hidden dim must match grad H");
+  NVTE_CHECK(grad_expert_out.scalar_type() == grad.scalar_type(), "grad_expert_out dtype (",
+             c10::toString(grad_expert_out.scalar_type()), ") must match grad dtype (",
+             c10::toString(grad.scalar_type()), ")");
+  // grad is autograd-allocated (staged-copy path); grad_expert_out is the
+  // EpBuffer-owned scatter target and must be symm-mem in zero-copy mode.
+  check_symm_mem_required(grad_expert_out, "grad_expert_out");
+
+  auto g_dtype = GetTransformerEngineDType(grad.scalar_type());
+  auto handle_mem_te = makeTransformerEngineTensor(
+      handle_mem.data_ptr(), Shape{static_cast<size_t>(handle_mem.numel())}, DType::kByte);
+  auto grad_te = makeTransformerEngineTensor(grad.data_ptr(), Shape{T_flat, H}, g_dtype);
+  auto grad_expert_out_te =
+      makeTransformerEngineTensor(grad_expert_out.data_ptr(), Shape{recv_pr, H}, g_dtype);
+
+  // grad is autograd-allocated (staged); grad_expert_out resolves to a symm-mem
+  // window in zero-copy mode, else kNoWindow for the staged path.
+  NVTECommWindow grad_win = maybe_make_window(grad);
+  NVTECommWindow grad_expert_out_win = maybe_make_window(grad_expert_out);
+  nvte_ep_combine_bwd(handle_mem_te.data(), grad_te.data(), grad_win, grad_expert_out_te.data(),
+                      grad_expert_out_win, stream);
+}
+
+void register_ep_bindings(pybind11::module_& m) {
+  namespace py = pybind11;
+  m.def("ep_initialize", &ep_initialize,
+        "Initialize the EP backend; borrows torch's NCCL comm pointed to by ``comm_ptr``.",
+        py::arg("comm_ptr"), py::arg("group_name"), py::arg("num_experts"),
+        py::arg("max_tokens_per_rank"), py::arg("max_recv_tokens_per_rank"), py::arg("hidden_dim"),
+        py::arg("max_num_sms") = 0, py::arg("max_token_dtype"), py::arg("zero_copy") = false,
+        py::call_guard<py::gil_scoped_release>());
+  m.def("ep_finalize", &ep_finalize, "Tear down the EP backend. Idempotent.",
+        py::call_guard<py::gil_scoped_release>());
+  m.def("ep_get_zero_copy", &ep_get_zero_copy, "Return the current EP zero-copy toggle state.");
+  m.def("ep_handle_mem_size", &ep_handle_mem_size,
+        "Return the handle_mem byte size for the given layer config.", py::arg("top_k"),
+        py::arg("dispatch_output_per_expert_alignment") = 0);
+  m.def("ep_prepare", &ep_prepare, "EP prepare", py::call_guard<py::gil_scoped_release>());
+  m.def("ep_dispatch", &ep_dispatch, "EP dispatch", py::call_guard<py::gil_scoped_release>());
+  m.def("ep_combine", &ep_combine, "EP combine", py::call_guard<py::gil_scoped_release>());
+  m.def("ep_dispatch_bwd", &ep_dispatch_bwd, "EP dispatch backward",
+        py::call_guard<py::gil_scoped_release>());
+  m.def("ep_combine_bwd", &ep_combine_bwd, "EP combine backward",
+        py::call_guard<py::gil_scoped_release>());
+}
+
+}  // namespace transformer_engine::pytorch
+
+#endif  // NVTE_WITH_NCCL_EP

--- a/transformer_engine/pytorch/csrc/extensions/pybind.cpp
+++ b/transformer_engine/pytorch/csrc/extensions/pybind.cpp
@@ -293,6 +293,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "DSquaredReLU + DBias + Quantize", py::arg("grad"), py::arg("fwd_input"),
         py::arg("quantizer"));
 
+#ifdef NVTE_WITH_NCCL_EP
+  transformer_engine::pytorch::register_ep_bindings(m);
+#endif  // NVTE_WITH_NCCL_EP
+
   // Permutation functions
   m.def("moe_permute_fwd", transformer_engine::pytorch::moe_permute_fwd, "MOE permute FWD",
         py::call_guard<py::gil_scoped_release>());

--- a/transformer_engine/pytorch/distributed.py
+++ b/transformer_engine/pytorch/distributed.py
@@ -1842,6 +1842,27 @@ def get_symmetric_memory_tensor(tensor_numel, tensor_dtype, tensor_device, tp_gr
     return msg
 
 
+def symm_mem_alloc(
+    shape,
+    dtype: torch.dtype,
+    ep_group: dist_group_type,
+    device: Optional[torch.device] = None,
+) -> torch.Tensor:
+    """Allocate and rendezvous a symm-mem buffer on ep_group. Collective on ep_group."""
+    if device is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    if not HAS_TORCH_SYMMETRIC:
+        raise RuntimeError(
+            "torch.distributed._symmetric_memory is unavailable; symm_mem_alloc "
+            "requires PyTorch built with NCCL symm-mem support."
+        )
+    if symm_mem.get_backend(device) != "NCCL":
+        symm_mem.set_backend("NCCL")
+    t = symm_mem.empty(*shape, dtype=dtype, device=device)
+    symm_mem.rendezvous(t, group=ep_group)
+    return t
+
+
 def symmetric_all_reduce(
     inp: torch.Tensor,
     tp_group: Optional[dist_group_type] = None,

--- a/transformer_engine/pytorch/dynamo.py
+++ b/transformer_engine/pytorch/dynamo.py
@@ -9,12 +9,14 @@ This module isolates the torch.compile-specific plumbing that turns a
 
   * :func:`register_value_opaque_quantizer` -- attaches the ``__fx_repr__`` used
     by FX codegen and registers the quantizer class with
-    ``torch._library.opaque_object``. It is a no-op (other than populating the
-    local registry) on PyTorch builds without the opaque-object API, so
-    importing Transformer Engine never fails on older PyTorch -- only
-    torch.compile specialization on the quantizer is unavailable there.
-  * :func:`_quantizer_from_value_key` -- rebuilds a quantizer constant from its
-    value key inside the generated FX graph.
+    ``torch._library.opaque_object``. It is a no-op on PyTorch builds without
+    the opaque-object API, so importing Transformer Engine never fails on older
+    PyTorch -- only torch.compile specialization on the quantizer is
+    unavailable there.
+  * :func:`_rebuild_quantizer` -- rebuilds a quantizer constant from its value
+    items inside the generated FX graph. The quantizer class is captured
+    directly in the FX globals (see :func:`_quantizer_fx_repr`), so no global
+    class registry is needed.
 
 The eager value semantics (``__eq__`` / ``__hash__`` / ``_value_key`` /
 ``_value_fields``) live on the quantizer itself; see
@@ -22,7 +24,10 @@ The eager value semantics (``__eq__`` / ``__hash__`` / ``_value_key`` /
 
 See ``torch._library.opaque_object`` Note [Opaque Objects] for the contract a
 value-typed opaque object must satisfy (``__eq__`` / ``__hash__`` /
-``__fx_repr__``).
+``__fx_repr__``). The ``__fx_repr__`` contract -- ``(repr_string, {name: type})``
+where ``repr_string`` references the names in the dict -- is exactly how
+PyTorch's own value opaque types (e.g. DTensor placements) reconstruct
+themselves, including across the on-disk compile cache.
 """
 
 from __future__ import annotations
@@ -31,26 +36,16 @@ from typing import Any, Dict, Tuple
 from .constants import DType
 
 
-# Maps a quantizer class qualname to the class object. A value key stores only
-# the qualname, so reconstruction looks the class up here. Populated by
-# ``register_value_opaque_quantizer`` at import time of each tensor module; this
-# avoids importing the tensor modules into this module (which would create an
-# import cycle).
-_QUANTIZER_VALUE_REGISTRY: Dict[str, type] = {}
-
-
-def _quantizer_from_value_key(key: Tuple[Any, ...]) -> Any:
-    """Rebuild a tensorless quantizer from its value key.
+def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
+    """Rebuild a tensorless quantizer of type *cls* from its value items.
 
     Referenced by the ``__fx_repr__`` emitted for value-opaque quantizers; the
     generated FX code calls this to materialize the quantizer constant. The
     deprecated amax-reduction process group is never part of the value, so a
     reconstructed quantizer always starts with no stored group.
     """
-    qualname, items = key[0], key[1]
-    cls = _QUANTIZER_VALUE_REGISTRY[qualname]
     # Bypass ``__init__`` and restore the value attributes directly: the value
-    # key already captures every value-defining field (including derived ones),
+    # items already capture every value-defining field (including derived ones),
     # and the constructors have heterogeneous signatures / side effects.
     obj = cls.__new__(cls)
     field_names = set()
@@ -71,12 +66,15 @@ def _quantizer_fx_repr(self: Any) -> Tuple[str, Dict[str, Any]]:
     """``__fx_repr__`` for value-opaque quantizers (attached at registration).
 
     Returns an evaluable expression that rebuilds the quantizer via
-    :func:`_quantizer_from_value_key`, together with the globals needed to
-    evaluate it.
+    :func:`_rebuild_quantizer`, capturing both the helper and the quantizer
+    class itself in the FX globals so codegen can resolve them with no global
+    registry and no qualname collisions.
     """
+    cls = type(self)
+    items = self._value_key()[1]
     return (
-        f"_quantizer_from_value_key({self._value_key()!r})",
-        {"_quantizer_from_value_key": _quantizer_from_value_key},
+        f"_rebuild_quantizer({cls.__name__}, {items!r})",
+        {"_rebuild_quantizer": _rebuild_quantizer, cls.__name__: cls},
     )
 
 
@@ -85,16 +83,13 @@ def register_value_opaque_quantizer(cls: type) -> None:
 
     Attaches ``__fx_repr__`` and registers the class with
     ``torch._library.opaque_object``. Safe to call on any PyTorch build: on
-    versions without the opaque-object API it only records the class in the
-    local registry and attaches ``__fx_repr__`` (both harmless), so Transformer
-    Engine keeps importing and running in eager mode.
+    versions without the opaque-object API it only attaches ``__fx_repr__``
+    (harmless), so Transformer Engine keeps importing and running in eager mode.
 
     The quantizer class must already provide value ``__eq__`` / ``__hash__`` and
     a non-``None`` ``_value_fields`` (see
     :class:`transformer_engine.pytorch.quantized_tensor.Quantizer`).
     """
-    _QUANTIZER_VALUE_REGISTRY[cls.__qualname__] = cls
-
     # ``register_opaque_type`` requires ``__fx_repr__`` to already exist on the
     # class, so attach it before registering.
     if "__fx_repr__" not in cls.__dict__:

--- a/transformer_engine/pytorch/dynamo.py
+++ b/transformer_engine/pytorch/dynamo.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""torch.compile glue for Transformer Engine quantizers.
+
+This module isolates the torch.compile-specific plumbing that turns a
+*tensorless* quantizer into a torch.compile **value** opaque type:
+
+  * :func:`register_value_opaque_quantizer` -- attaches the ``__fx_repr__`` used
+    by FX codegen and registers the quantizer class with
+    ``torch._library.opaque_object``. It is a no-op (other than populating the
+    local registry) on PyTorch builds without the opaque-object API, so
+    importing Transformer Engine never fails on older PyTorch -- only
+    torch.compile specialization on the quantizer is unavailable there.
+  * :func:`_quantizer_from_value_key` -- rebuilds a quantizer constant from its
+    value key inside the generated FX graph.
+
+The eager value semantics (``__eq__`` / ``__hash__`` / ``_value_key`` /
+``_value_fields``) live on the quantizer itself; see
+:class:`transformer_engine.pytorch.quantized_tensor.Quantizer`.
+
+See ``torch._library.opaque_object`` Note [Opaque Objects] for the contract a
+value-typed opaque object must satisfy (``__eq__`` / ``__hash__`` /
+``__fx_repr__``).
+"""
+
+from __future__ import annotations
+from typing import Any, Dict, Tuple
+
+from .constants import DType
+
+
+# Maps a quantizer class qualname to the class object. A value key stores only
+# the qualname, so reconstruction looks the class up here. Populated by
+# ``register_value_opaque_quantizer`` at import time of each tensor module; this
+# avoids importing the tensor modules into this module (which would create an
+# import cycle).
+_QUANTIZER_VALUE_REGISTRY: Dict[str, type] = {}
+
+
+def _quantizer_from_value_key(key: Tuple[Any, ...]) -> Any:
+    """Rebuild a tensorless quantizer from its value key.
+
+    Referenced by the ``__fx_repr__`` emitted for value-opaque quantizers; the
+    generated FX code calls this to materialize the quantizer constant. The
+    deprecated amax-reduction process group is never part of the value, so a
+    reconstructed quantizer always starts with no stored group.
+    """
+    qualname, items = key[0], key[1]
+    cls = _QUANTIZER_VALUE_REGISTRY[qualname]
+    # Bypass ``__init__`` and restore the value attributes directly: the value
+    # key already captures every value-defining field (including derived ones),
+    # and the constructors have heterogeneous signatures / side effects.
+    obj = cls.__new__(cls)
+    field_names = set()
+    for name, value in items:
+        if name == "dtype":
+            value = DType.cast(value)
+        object.__setattr__(obj, name, value)
+        field_names.add(name)
+    # The deprecated amax-reduction process group is excluded from the value;
+    # restore it as ``None`` for quantizers that still carry the fallback so
+    # attribute access keeps working.
+    if "with_amax_reduction" in field_names and not hasattr(obj, "amax_reduction_group"):
+        object.__setattr__(obj, "amax_reduction_group", None)
+    return obj
+
+
+def _quantizer_fx_repr(self: Any) -> Tuple[str, Dict[str, Any]]:
+    """``__fx_repr__`` for value-opaque quantizers (attached at registration).
+
+    Returns an evaluable expression that rebuilds the quantizer via
+    :func:`_quantizer_from_value_key`, together with the globals needed to
+    evaluate it.
+    """
+    return (
+        f"_quantizer_from_value_key({self._value_key()!r})",
+        {"_quantizer_from_value_key": _quantizer_from_value_key},
+    )
+
+
+def register_value_opaque_quantizer(cls: type) -> None:
+    """Register a tensorless quantizer class as a torch.compile value opaque type.
+
+    Attaches ``__fx_repr__`` and registers the class with
+    ``torch._library.opaque_object``. Safe to call on any PyTorch build: on
+    versions without the opaque-object API it only records the class in the
+    local registry and attaches ``__fx_repr__`` (both harmless), so Transformer
+    Engine keeps importing and running in eager mode.
+
+    The quantizer class must already provide value ``__eq__`` / ``__hash__`` and
+    a non-``None`` ``_value_fields`` (see
+    :class:`transformer_engine.pytorch.quantized_tensor.Quantizer`).
+    """
+    _QUANTIZER_VALUE_REGISTRY[cls.__qualname__] = cls
+
+    # ``register_opaque_type`` requires ``__fx_repr__`` to already exist on the
+    # class, so attach it before registering.
+    if "__fx_repr__" not in cls.__dict__:
+        cls.__fx_repr__ = _quantizer_fx_repr
+
+    try:
+        from torch._library.opaque_object import (  # pylint: disable=import-outside-toplevel
+            register_opaque_type,
+            is_opaque_value_type,
+        )
+    except (ImportError, AttributeError):
+        # Older PyTorch without the opaque-object API: eager value semantics
+        # still work; torch.compile specialization on the quantizer does not.
+        return
+
+    if is_opaque_value_type(cls):
+        return
+
+    try:
+        register_opaque_type(cls, typ="value")
+    except (ImportError, AttributeError, RuntimeError, TypeError):
+        # Tolerate partial / experimental opaque-object support.
+        pass

--- a/transformer_engine/pytorch/dynamo/__init__.py
+++ b/transformer_engine/pytorch/dynamo/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""torch.compile glue for Transformer Engine.
+
+Public API is re-exported here so callers keep importing from
+``transformer_engine.pytorch.dynamo`` regardless of the internal module layout:
+
+  * :mod:`.quantizer_opaque` -- make a tensorless quantizer a torch.compile
+    *value* opaque type (:func:`register_value_opaque_quantizer`).
+"""
+
+from .quantizer_opaque import register_value_opaque_quantizer
+
+__all__ = [
+    "register_value_opaque_quantizer",
+]

--- a/transformer_engine/pytorch/dynamo/__init__.py
+++ b/transformer_engine/pytorch/dynamo/__init__.py
@@ -4,8 +4,9 @@
 
 """torch.compile glue for Transformer Engine."""
 
-from .quantizer_opaque import register_value_opaque_quantizer
+from .quantizer_opaque import register_value_opaque_quantizer, is_value_opaque_quantizer
 
 __all__ = [
     "register_value_opaque_quantizer",
+    "is_value_opaque_quantizer",
 ]

--- a/transformer_engine/pytorch/dynamo/__init__.py
+++ b/transformer_engine/pytorch/dynamo/__init__.py
@@ -2,14 +2,7 @@
 #
 # See LICENSE for license information.
 
-"""torch.compile glue for Transformer Engine.
-
-Public API is re-exported here so callers keep importing from
-``transformer_engine.pytorch.dynamo`` regardless of the internal module layout:
-
-  * :mod:`.quantizer_opaque` -- make a tensorless quantizer a torch.compile
-    *value* opaque type (:func:`register_value_opaque_quantizer`).
-"""
+"""torch.compile glue for Transformer Engine."""
 
 from .quantizer_opaque import register_value_opaque_quantizer
 

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -2,46 +2,35 @@
 #
 # See LICENSE for license information.
 
-"""Value-opaque quantizers for torch.compile.
-
-Turns a *tensorless* quantizer into a torch.compile **value** opaque type:
-
-  * :func:`register_value_opaque_quantizer` -- attaches the ``__fx_repr__`` used
-    by FX codegen and registers the quantizer class with
-    ``torch._library.opaque_object``. It is a no-op on PyTorch builds without
-    the opaque-object API, so importing Transformer Engine never fails on older
-    PyTorch -- only torch.compile specialization on the quantizer is
-    unavailable there.
-  * :func:`_rebuild_quantizer` -- rebuilds a quantizer constant from its value
-    items inside the generated FX graph. The quantizer class is captured
-    directly in the FX globals (see :func:`_quantizer_fx_repr`), so no global
-    class registry is needed.
-
-The eager value semantics (``__eq__`` / ``__hash__`` / ``_value_key`` /
-``_value_fields``) live on the quantizer itself; see
-:class:`transformer_engine.pytorch.quantized_tensor.Quantizer`.
-
-See ``torch._library.opaque_object`` Note [Opaque Objects] for the contract a
-value-typed opaque object must satisfy (``__eq__`` / ``__hash__`` /
-``__fx_repr__``). The ``__fx_repr__`` contract -- ``(repr_string, {name: type})``
-where ``repr_string`` references the names in the dict -- is exactly how
-PyTorch's own value opaque types (e.g. DTensor placements) reconstruct
-themselves, including across the on-disk compile cache.
-"""
+"""Value-opaque quantizers for torch.compile."""
 
 from __future__ import annotations
 from typing import Any, Dict, Tuple
 
-from ..constants import DType
+from ..constants import DType, dist_group_type
+
+
+def _contains_process_group(value: Any) -> bool:
+    """Whether *value* is (or nests) a ``torch.distributed.ProcessGroup``.
+
+    Checks the value directly and one level of ``tuple``/``list`` nesting, which
+    covers the shapes a quantizer value field could plausibly take.
+    """
+    if isinstance(value, dist_group_type):
+        return True
+    if isinstance(value, (tuple, list)):
+        return any(_contains_process_group(item) for item in value)
+    return False
 
 
 def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
     """Rebuild a tensorless quantizer of type *cls* from its value items.
 
     Referenced by the ``__fx_repr__`` emitted for value-opaque quantizers; the
-    generated FX code calls this to materialize the quantizer constant. The
-    deprecated amax-reduction process group is never part of the value, so a
-    reconstructed quantizer always starts with no stored group.
+    generated FX code calls this to materialize the quantizer constant. A
+    quantizer that actually stores a process group never reaches this path:
+    ``__fx_repr__`` raises for it. The deprecated amax-reduction group is not a
+    value field, so the rebuilt quantizer simply has no group attribute.
     """
     # Bypass ``__init__`` and restore the value attributes directly: the value
     # items already capture every value-defining field (including derived ones),
@@ -53,9 +42,9 @@ def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
             value = DType.cast(value)
         object.__setattr__(obj, name, value)
         field_names.add(name)
-    # The deprecated amax-reduction process group is excluded from the value;
-    # restore it as ``None`` for quantizers that still carry the fallback so
-    # attribute access keeps working.
+    # The deprecated amax-reduction group is not a value field. Quantizers that
+    # actually hold a group error out in ``__fx_repr__`` before reaching here, so
+    # this only initializes the (groupless) attribute to keep access working.
     if "with_amax_reduction" in field_names and not hasattr(obj, "amax_reduction_group"):
         object.__setattr__(obj, "amax_reduction_group", None)
     return obj
@@ -68,8 +57,23 @@ def _quantizer_fx_repr(self: Any) -> Tuple[str, Dict[str, Any]]:
     :func:`_rebuild_quantizer`, capturing both the helper and the quantizer
     class itself in the FX globals so codegen can resolve them with no global
     registry and no qualname collisions.
+
+    Raises ``TypeError`` if the quantizer stores a process group (e.g. a
+    non-``None`` deprecated ``amax_reduction_group``): live distributed state
+    must never be baked into the graph as a constant, so such a quantizer cannot
+    be used with ``torch.compile``. Pass the reduction group per quantize call
+    instead of storing it on the quantizer.
     """
     cls = type(self)
+    for name, value in vars(self).items():
+        if _contains_process_group(value):
+            raise TypeError(
+                f"{cls.__name__} cannot be used with torch.compile: attribute "
+                f"{name!r} holds a torch.distributed.ProcessGroup, which is live "
+                "distributed state and must not be baked into an FX graph as a "
+                "constant. Pass the amax reduction group per quantize call instead "
+                "of storing it on the quantizer."
+            )
     items = self._value_key()[1]
     return (
         f"_rebuild_quantizer({cls.__name__}, {items!r})",

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -10,6 +10,17 @@ from typing import Any, Dict, Tuple
 from ..constants import DType, dist_group_type
 
 
+# Class attribute stamped on quantizers registered as torch.compile value-opaque
+# types.
+_VALUE_OPAQUE_FLAG = "_te_compile_value_opaque"
+
+
+def is_value_opaque_quantizer(quantizer: Any) -> bool:
+    """Whether *quantizer*'s class is registered as a torch.compile value-opaque
+    type."""
+    return getattr(quantizer, _VALUE_OPAQUE_FLAG, False)
+
+
 def _contains_process_group(value: Any) -> bool:
     """Whether *value* is (or nests) a ``torch.distributed.ProcessGroup``.
 
@@ -93,6 +104,10 @@ def register_value_opaque_quantizer(cls: type) -> None:
     a non-``None`` ``_value_fields`` (see
     :class:`transformer_engine.pytorch.quantized_tensor.Quantizer`).
     """
+    # Stamp the class so it can be recognized as value-opaque in dynamo-traced
+    # code (used to fall back to eager for unregistered quantizers).
+    setattr(cls, _VALUE_OPAQUE_FLAG, True)
+
     # ``register_opaque_type`` requires ``__fx_repr__`` to already exist on the
     # class, so attach it before registering.
     if "__fx_repr__" not in cls.__dict__:

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -2,10 +2,9 @@
 #
 # See LICENSE for license information.
 
-"""torch.compile glue for Transformer Engine quantizers.
+"""Value-opaque quantizers for torch.compile.
 
-This module isolates the torch.compile-specific plumbing that turns a
-*tensorless* quantizer into a torch.compile **value** opaque type:
+Turns a *tensorless* quantizer into a torch.compile **value** opaque type:
 
   * :func:`register_value_opaque_quantizer` -- attaches the ``__fx_repr__`` used
     by FX codegen and registers the quantizer class with
@@ -33,7 +32,7 @@ themselves, including across the on-disk compile cache.
 from __future__ import annotations
 from typing import Any, Dict, Tuple
 
-from .constants import DType
+from ..constants import DType
 
 
 def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -58,6 +58,11 @@ def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
     # this only initializes the (groupless) attribute to keep access working.
     if "with_amax_reduction" in field_names and not hasattr(obj, "amax_reduction_group"):
         object.__setattr__(obj, "amax_reduction_group", None)
+    # Restore non-value derived state that ``__init__`` would normally build but
+    # that cannot live in the value key (e.g. NVFP4's ``rht_matrix`` tensor).
+    finalize = getattr(obj, "_rebuild_derived_state", None)
+    if finalize is not None:
+        finalize()
     return obj
 
 

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -25,10 +25,7 @@ def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
     """Rebuild a tensorless quantizer of type *cls* from its value items.
 
     Referenced by the ``__fx_repr__`` emitted for value-opaque quantizers; the
-    generated FX code calls this to materialize the quantizer constant. A
-    quantizer that actually stores a process group never reaches this path:
-    ``__fx_repr__`` raises for it. The deprecated amax-reduction group is not a
-    value field, so the rebuilt quantizer simply has no group attribute.
+    generated FX code calls this to materialize the quantizer constant.
     """
     # Bypass ``__init__`` and restore the value attributes directly: the value
     # items already capture every value-defining field (including derived ones),
@@ -40,9 +37,8 @@ def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
             value = DType.cast(value)
         object.__setattr__(obj, name, value)
         field_names.add(name)
-    # The deprecated amax-reduction group is not a value field. Quantizers that
-    # actually hold a group error out in ``__fx_repr__`` before reaching here, so
-    # this only initializes the (groupless) attribute to keep access working.
+    # The deprecated amax-reduction group is not a value field; initialize it to
+    # None so attribute access keeps working on the rebuilt quantizer.
     if "with_amax_reduction" in field_names and not hasattr(obj, "amax_reduction_group"):
         object.__setattr__(obj, "amax_reduction_group", None)
     # Restore non-value derived state that ``__init__`` would normally build but

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -87,12 +87,10 @@ def register_value_opaque_quantizer(cls: type) -> None:
     a non-``None`` ``_value_fields`` (see
     :class:`transformer_engine.pytorch.quantized_tensor.Quantizer`).
     """
-    # Stamp the class so it can be recognized as value-opaque in dynamo-traced
-    # code (used to fall back to eager for unregistered quantizers).
-    setattr(cls, _VALUE_OPAQUE_FLAG, True)
-
     # ``register_opaque_type`` requires ``__fx_repr__`` to already exist on the
-    # class, so attach it before registering.
+    # class, so attach it before registering. Eager value semantics
+    # (``__eq__`` / ``__hash__`` / ``__fx_repr__``) work regardless of whether
+    # the opaque-object registration below succeeds.
     if "__fx_repr__" not in cls.__dict__:
         cls.__fx_repr__ = _quantizer_fx_repr
 
@@ -113,4 +111,9 @@ def register_value_opaque_quantizer(cls: type) -> None:
         # Keep TE importable: neither the opaque-type query nor the registration
         # must crash the import, e.g. on PyTorch versions with only partial /
         # experimental opaque-object support.
-        pass
+        return
+
+    # Stamp the class only once torch actually knows it as an opaque value type,
+    # so ``is_value_opaque_quantizer`` never reports a quantizer as opaque when
+    # the registration was skipped or failed.
+    setattr(cls, _VALUE_OPAQUE_FLAG, True)

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -88,9 +88,7 @@ def register_value_opaque_quantizer(cls: type) -> None:
     :class:`transformer_engine.pytorch.quantized_tensor.Quantizer`).
     """
     # ``register_opaque_type`` requires ``__fx_repr__`` to already exist on the
-    # class, so attach it before registering. Eager value semantics
-    # (``__eq__`` / ``__hash__`` / ``__fx_repr__``) work regardless of whether
-    # the opaque-object registration below succeeds.
+    # class, so attach it before registering.
     if "__fx_repr__" not in cls.__dict__:
         cls.__fx_repr__ = _quantizer_fx_repr
 
@@ -113,7 +111,4 @@ def register_value_opaque_quantizer(cls: type) -> None:
         # experimental opaque-object support.
         return
 
-    # Stamp the class only once torch actually knows it as an opaque value type,
-    # so ``is_value_opaque_quantizer`` never reports a quantizer as opaque when
-    # the registration was skipped or failed.
     setattr(cls, _VALUE_OPAQUE_FLAG, True)

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -10,12 +10,12 @@ from typing import Any, Dict, Tuple
 from ..constants import DType
 
 
-# Registration marks the class with this attribute instead of recording it in a
-# module-level set. ``is_value_opaque_quantizer`` runs *inside* the torch.compile
-# graph (``Linear.forward`` consults it): Dynamo can trace a ``getattr`` on the
-# opaque quantizer and bake the result as a constant, but cannot evaluate
-# ``type(q) in some_set`` -- it has no equality/hash rules for the opaque class
-# object, so a set/dict lookup graph-breaks under ``fullgraph=True``.
+# Registration marks the class with this attribute rather than recording it in a
+# module-level set. It looks odd but is a deliberate workaround: the check must
+# stay traceable when it runs inside a torch.compile graph -- Dynamo can bake a
+# ``getattr`` on the opaque quantizer into a constant, but cannot evaluate
+# ``type(q) in some_set`` (no equality/hash rules for the opaque class object),
+# which would graph-break under ``fullgraph=True``.
 _VALUE_OPAQUE_FLAG = "_te_compile_value_opaque"
 
 

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 from typing import Any, Dict, Tuple
 
-from ..constants import DType, dist_group_type
+from ..constants import DType
 
 
 # Class attribute stamped on quantizers registered as torch.compile value-opaque
@@ -19,19 +19,6 @@ def is_value_opaque_quantizer(quantizer: Any) -> bool:
     """Whether *quantizer*'s class is registered as a torch.compile value-opaque
     type."""
     return getattr(quantizer, _VALUE_OPAQUE_FLAG, False)
-
-
-def _contains_process_group(value: Any) -> bool:
-    """Whether *value* is (or nests) a ``torch.distributed.ProcessGroup``.
-
-    Checks the value directly and one level of ``tuple``/``list`` nesting, which
-    covers the shapes a quantizer value field could plausibly take.
-    """
-    if isinstance(value, dist_group_type):
-        return True
-    if isinstance(value, (tuple, list)):
-        return any(_contains_process_group(item) for item in value)
-    return False
 
 
 def _rebuild_quantizer(cls: type, items: Tuple[Tuple[str, Any], ...]) -> Any:
@@ -74,22 +61,13 @@ def _quantizer_fx_repr(self: Any) -> Tuple[str, Dict[str, Any]]:
     class itself in the FX globals so codegen can resolve them with no global
     registry and no qualname collisions.
 
-    Raises ``TypeError`` if the quantizer stores a process group (e.g. a
-    non-``None`` deprecated ``amax_reduction_group``): live distributed state
-    must never be baked into the graph as a constant, so such a quantizer cannot
-    be used with ``torch.compile``. Pass the reduction group per quantize call
-    instead of storing it on the quantizer.
+    Raises ``TypeError`` (via :meth:`Quantizer._value_key`) if the quantizer
+    stores a process group (e.g. a non-``None`` deprecated
+    ``amax_reduction_group``): live distributed state must never be baked into
+    the graph as a constant. Pass the reduction group per quantize call instead
+    of storing it on the quantizer.
     """
     cls = type(self)
-    for name, value in vars(self).items():
-        if _contains_process_group(value):
-            raise TypeError(
-                f"{cls.__name__} cannot be used with torch.compile: attribute "
-                f"{name!r} holds a torch.distributed.ProcessGroup, which is live "
-                "distributed state and must not be baked into an FX graph as a "
-                "constant. Pass the amax reduction group per quantize call instead "
-                "of storing it on the quantizer."
-            )
     items = self._value_key()[1]
     return (
         f"_rebuild_quantizer({cls.__name__}, {items!r})",

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -106,12 +106,11 @@ def register_value_opaque_quantizer(cls: type) -> None:
         # still work; torch.compile specialization on the quantizer does not.
         return
 
-    if is_opaque_value_type(cls):
-        return
-
     try:
-        register_opaque_type(cls, typ="value")
+        if not is_opaque_value_type(cls):
+            register_opaque_type(cls, typ="value")
     except (RuntimeError, TypeError):
-        # Keep TE importable: registration must never crash the import, e.g. on
-        # PyTorch versions with only partial / experimental opaque-object support.
+        # Keep TE importable: neither the opaque-type query nor the registration
+        # must crash the import, e.g. on PyTorch versions with only partial /
+        # experimental opaque-object support.
         pass

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -10,8 +10,12 @@ from typing import Any, Dict, Tuple
 from ..constants import DType
 
 
-# Class attribute stamped on quantizers registered as torch.compile value-opaque
-# types.
+# Registration marks the class with this attribute instead of recording it in a
+# module-level set. ``is_value_opaque_quantizer`` runs *inside* the torch.compile
+# graph (``Linear.forward`` consults it): Dynamo can trace a ``getattr`` on the
+# opaque quantizer and bake the result as a constant, but cannot evaluate
+# ``type(q) in some_set`` -- it has no equality/hash rules for the opaque class
+# object, so a set/dict lookup graph-breaks under ``fullgraph=True``.
 _VALUE_OPAQUE_FLAG = "_te_compile_value_opaque"
 
 

--- a/transformer_engine/pytorch/dynamo/quantizer_opaque.py
+++ b/transformer_engine/pytorch/dynamo/quantizer_opaque.py
@@ -128,6 +128,7 @@ def register_value_opaque_quantizer(cls: type) -> None:
 
     try:
         register_opaque_type(cls, typ="value")
-    except (ImportError, AttributeError, RuntimeError, TypeError):
-        # Tolerate partial / experimental opaque-object support.
+    except (RuntimeError, TypeError):
+        # Keep TE importable: registration must never crash the import, e.g. on
+        # PyTorch versions with only partial / experimental opaque-object support.
         pass

--- a/transformer_engine/pytorch/ep.py
+++ b/transformer_engine/pytorch/ep.py
@@ -1,0 +1,610 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+"""PyTorch Expert Parallelism (EP) API."""
+
+from __future__ import annotations
+
+import atexit
+import warnings
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+import transformer_engine_torch as tex
+
+from .cpu_offload import mark_not_offload
+from .distributed import symm_mem_alloc
+
+
+__all__ = [
+    "EpBuffer",
+    "ep_bootstrap",
+    "ep_finalize",
+    "ep_dispatch",
+    "ep_combine",
+    "symm_mem_alloc",
+]
+
+
+# ``symm_mem_alloc`` (imported from .distributed) allocates the symm-mem buffers
+# used by the zero-copy IO path. Set ``ep_bootstrap(zero_copy=True)`` to opt in;
+# the C++ backend then operates the EP group in zero-copy mode.
+
+
+# Bootstrap
+
+
+# NCCL EP requires NCCL >= 2.30.4 (matches the C++ backend's runtime check).
+_MIN_NCCL_VERSION = (2, 30, 4)
+
+
+def _check_nccl_runtime_version() -> None:
+    """Raise with a clear message if the loaded libnccl is too old for NCCL EP."""
+    import ctypes
+
+    try:
+        lib = ctypes.CDLL("libnccl.so.2", mode=ctypes.RTLD_GLOBAL)
+        v = ctypes.c_int(0)
+        if lib.ncclGetVersion(ctypes.byref(v)) != 0:
+            warnings.warn("ncclGetVersion failed; skipping NCCL EP version check.")
+            return
+    except OSError:  # libnccl not findable; let the C++ side error
+        return
+    n = v.value
+    # NCCL packs as (major*10000 + minor*100 + patch) up to ~2.x; newer
+    # builds use the same scheme. Decode defensively.
+    major, minor, patch = n // 10000, (n // 100) % 100, n % 100
+    if (major, minor, patch) < _MIN_NCCL_VERSION:
+        min_str = ".".join(str(x) for x in _MIN_NCCL_VERSION)
+        raise RuntimeError(
+            f"NCCL EP requires NCCL >= {min_str}, found {major}.{minor}.{patch} at runtime. "
+            "Set LD_LIBRARY_PATH to a newer libnccl.so before launching."
+        )
+
+
+_BOOTSTRAPPED = False
+_ATEXIT_REGISTERED = False
+# EP group captured at bootstrap; EpBuffer uses it to allocate the symm-mem
+# combine grad buffer in zero-copy mode.
+_EP_GROUP: Optional[dist.ProcessGroup] = None
+
+
+def _atexit_finalize() -> None:
+    """Best-effort teardown at interpreter shutdown; swallows errors."""
+    global _BOOTSTRAPPED, _EP_GROUP
+    if _BOOTSTRAPPED:
+        try:
+            tex.ep_finalize()
+        except Exception:  # pylint: disable=broad-exception-caught
+            import traceback
+
+            traceback.print_exc()
+        finally:
+            _BOOTSTRAPPED = False
+            _EP_GROUP = None
+
+
+def ep_bootstrap(
+    ep_group: dist.ProcessGroup,
+    num_experts: int,
+    max_tokens_per_rank: int,
+    recv_capacity_per_rank: int,
+    hidden_dim: int,
+    max_num_sms: int = 0,
+    zero_copy: bool = False,
+    max_token_dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    """Initialize EP by borrowing ep_group's NCCL comm. Call once per process.
+
+    max_token_dtype sets the widest token dtype this EP group will dispatch;
+    it sizes NCCL EP staging buffers.
+
+    ``zero_copy`` opts the EP group into the symm-mem zero-copy IO path; pass
+    ``True`` only when payload tensors are allocated via ``symm_mem_alloc``.
+    Defaults to ``False``.
+    """
+    global _BOOTSTRAPPED, _ATEXIT_REGISTERED, _EP_GROUP
+    if _BOOTSTRAPPED:
+        raise RuntimeError("ep_bootstrap was already called in this process")
+    if ep_group.size() < 2:
+        raise ValueError(f"ep_bootstrap requires ep_group.size() >= 2 (got {ep_group.size()}).")
+    _check_nccl_runtime_version()
+    if zero_copy:
+        warnings.warn(
+            "ep_bootstrap(zero_copy=True) is experimental; the symm-mem IO path "
+            "and its alias contracts on EpBuffer slots are subject to change.",
+            stacklevel=2,
+        )
+
+    # Materialize the PG's NCCL comm before borrowing its raw handle.
+    dist.barrier(group=ep_group, device_ids=[torch.cuda.current_device()])
+    comm_ptr = ep_group._get_backend(torch.device("cuda"))._comm_ptr()
+
+    tex.ep_initialize(
+        int(comm_ptr),
+        str(ep_group.group_name),
+        int(num_experts),
+        int(max_tokens_per_rank),
+        int(recv_capacity_per_rank),
+        int(hidden_dim),
+        int(max_num_sms),
+        max_token_dtype,
+        bool(zero_copy),
+    )
+    _BOOTSTRAPPED = True
+    _EP_GROUP = ep_group
+    if not _ATEXIT_REGISTERED:
+        atexit.register(_atexit_finalize)
+        _ATEXIT_REGISTERED = True
+
+
+def ep_finalize() -> None:
+    """Optional explicit EP teardown; idempotent.
+
+    An atexit handler covers normal interpreter shutdown, so most users do not
+    need to call this. Call it explicitly only before
+    ``dist.destroy_process_group()``, since the borrowed NCCL comm becomes
+    invalid once the PG is destroyed.
+    """
+    global _BOOTSTRAPPED, _EP_GROUP
+    if not _BOOTSTRAPPED:
+        return
+    try:
+        tex.ep_finalize()
+    finally:
+        _BOOTSTRAPPED = False
+        _EP_GROUP = None
+
+
+# Buffer
+
+
+class EpBuffer:
+    """Per-microbatch EP layer state holding handle_mem and token_counts.
+    Use one EpBuffer per concurrently-in-flight call (e.g. per PP-1F1B microbatch).
+
+    In zero-copy mode the buffer owns the symm-mem buffers the one-sided path
+    requires: the dispatch recv outputs (recv_tokens, recv_topk_weights) and the
+    combine backward grad target. One set per buffer, so each layer/microbatch is
+    isolated. In normal mode these are None and allocated in-flight instead (recv
+    outputs in the dispatch forward, the combine grad in the backward).
+    """
+
+    __slots__ = (
+        "handle_mem",
+        "top_k",
+        "alignment",
+        "max_tokens_per_rank",
+        "recv_capacity_per_rank",
+        "hidden_dim",
+        "num_local_experts",
+        "payload_dtype",
+        "device",
+        "token_counts",
+        "zero_copy",
+        "recv_tokens_symm_buf",
+        "recv_topk_weights_symm_buf",
+        "grad_expert_out_symm_buf",
+    )
+
+    def _alloc_symm_buffers(self) -> None:
+        """Fill in buffer-owned symm-mem buffers the caller did not supply.
+        recv_topk_weights is always owned. In normal mode caller-supplied
+        tensors are kept as-is and the rest stay None (allocated in-flight)."""
+        if not self.zero_copy:
+            self.recv_topk_weights_symm_buf = None
+            return
+        if _EP_GROUP is None:
+            raise RuntimeError(
+                "ep_bootstrap must be called before constructing a zero-copy EpBuffer"
+            )
+        rc, h = self.recv_capacity_per_rank, self.hidden_dim
+        # Persistent across microbatches; keep resident under CPU offloading.
+        self.recv_topk_weights_symm_buf = symm_mem_alloc(
+            (rc,), torch.float32, _EP_GROUP, device=self.device
+        )
+        mark_not_offload(self.recv_topk_weights_symm_buf)
+        if self.recv_tokens_symm_buf is None:
+            self.recv_tokens_symm_buf = symm_mem_alloc(
+                (rc, h), self.payload_dtype, _EP_GROUP, device=self.device
+            )
+            mark_not_offload(self.recv_tokens_symm_buf)
+        if self.grad_expert_out_symm_buf is None:
+            self.grad_expert_out_symm_buf = symm_mem_alloc(
+                (rc, h), self.payload_dtype, _EP_GROUP, device=self.device
+            )
+            mark_not_offload(self.grad_expert_out_symm_buf)
+
+    def __init__(
+        self,
+        top_k: int,
+        max_tokens_per_rank: int,
+        recv_capacity_per_rank: int,
+        hidden_dim: int,
+        num_local_experts: int,
+        alignment: int = 0,
+        payload_dtype: torch.dtype = torch.bfloat16,
+        device: Optional[torch.device] = None,
+        dispatch_recv_tokens: Optional[torch.Tensor] = None,
+        combine_grad_expert_out: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Pass ``dispatch_recv_tokens`` (dispatch recv output) and/or
+        ``combine_grad_expert_out`` (combine backward grad target) to use caller-owned
+        buffers; the buffer then skips allocating them. Both must be symm-mem-backed
+        under zero-copy. Whatever is left None is buffer-owned (zero-copy) or allocated
+        in-flight (normal mode). recv_topk_weights is always owned by the buffer."""
+        if device is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        alignment = int(alignment)
+        if alignment > 1 and (alignment & (alignment - 1)) != 0:
+            raise ValueError(f"alignment must be 0, 1, or a power of two (got {alignment}).")
+        self.top_k = int(top_k)
+        self.alignment = alignment
+        self.max_tokens_per_rank = int(max_tokens_per_rank)
+        self.recv_capacity_per_rank = int(recv_capacity_per_rank)
+        self.hidden_dim = int(hidden_dim)
+        self.num_local_experts = int(num_local_experts)
+        self.payload_dtype = payload_dtype
+        self.device = device
+        self.zero_copy = bool(tex.ep_get_zero_copy())
+        self.recv_tokens_symm_buf = dispatch_recv_tokens
+        self.grad_expert_out_symm_buf = combine_grad_expert_out
+
+        size_bytes = tex.ep_handle_mem_size(self.top_k, self.alignment)
+        self.handle_mem = torch.empty(int(size_bytes), dtype=torch.uint8, device=device)
+        self.token_counts = torch.empty(self.num_local_experts, dtype=torch.int32, device=device)
+        # Persistent tensor; keep resident if activation CPU offloading is on.
+        mark_not_offload(self.handle_mem)
+        self._alloc_symm_buffers()
+
+
+# torch.library custom ops (so they don't graph-break under torch.compile)
+
+_LIB = "transformer_engine_ep"
+
+
+@torch.library.custom_op(
+    f"{_LIB}::prepare",
+    mutates_args=("handle_mem", "token_counts"),
+    device_types="cuda",
+)
+def _prepare_op(
+    handle_mem: torch.Tensor,
+    top_k: int,
+    topk_idx: torch.Tensor,
+    token_counts: torch.Tensor,
+    alignment: int,
+) -> None:
+    tex.ep_prepare(handle_mem, topk_idx, token_counts, top_k, alignment)
+
+
+@_prepare_op.register_fake
+def _(*_args, **_kw):
+    return None
+
+
+@torch.library.custom_op(
+    f"{_LIB}::dispatch",
+    mutates_args=("recv_tokens", "recv_topk_weights"),
+    device_types="cuda",
+)
+def _dispatch_op(
+    handle_mem: torch.Tensor,
+    topk_idx: torch.Tensor,
+    tokens: torch.Tensor,
+    topk_weights: torch.Tensor,
+    recv_tokens: torch.Tensor,
+    recv_topk_weights: torch.Tensor,
+) -> None:
+    tex.ep_dispatch(handle_mem, topk_idx, tokens, topk_weights, recv_tokens, recv_topk_weights)
+
+
+@_dispatch_op.register_fake
+def _(*_args, **_kw):
+    return None
+
+
+@torch.library.custom_op(
+    f"{_LIB}::combine",
+    mutates_args=("result",),
+    device_types="cuda",
+)
+def _combine_op(
+    handle_mem: torch.Tensor,
+    expert_out: torch.Tensor,
+    result: torch.Tensor,
+) -> None:
+    tex.ep_combine(handle_mem, expert_out, result)
+
+
+@_combine_op.register_fake
+def _(*_args, **_kw):
+    return None
+
+
+@torch.library.custom_op(
+    f"{_LIB}::dispatch_bwd",
+    mutates_args=("grad_tokens", "grad_topk_weights"),
+    device_types="cuda",
+)
+def _dispatch_bwd_op(
+    handle_mem: torch.Tensor,
+    grad: torch.Tensor,
+    g_recv_topk_weights: torch.Tensor,
+    grad_tokens: torch.Tensor,
+    grad_topk_weights: torch.Tensor,
+) -> None:
+    tex.ep_dispatch_bwd(handle_mem, grad, g_recv_topk_weights, grad_tokens, grad_topk_weights)
+
+
+@_dispatch_bwd_op.register_fake
+def _(*_args, **_kw):
+    return None
+
+
+@torch.library.custom_op(
+    f"{_LIB}::combine_bwd",
+    mutates_args=("grad_expert_out",),
+    device_types="cuda",
+)
+def _combine_bwd_op(
+    handle_mem: torch.Tensor,
+    grad: torch.Tensor,
+    grad_expert_out: torch.Tensor,
+) -> None:
+    tex.ep_combine_bwd(handle_mem, grad, grad_expert_out)
+
+
+@_combine_bwd_op.register_fake
+def _(*_args, **_kw):
+    return None
+
+
+# Non-autograd primitives
+
+
+def ep_prepare(buffer: "EpBuffer", topk_idx: torch.Tensor) -> torch.Tensor:
+    """AllGather the routing map; fills ``buffer.handle_mem`` and returns
+    ``buffer.token_counts`` (int32, shape [num_local_experts]). topk_idx must
+    be int64.
+    """
+    torch.ops.transformer_engine_ep.prepare(
+        buffer.handle_mem, buffer.top_k, topk_idx, buffer.token_counts, buffer.alignment
+    )
+    return buffer.token_counts
+
+
+def _ep_dispatch_raw(
+    buffer: "EpBuffer",
+    topk_idx: torch.Tensor,
+    tokens: torch.Tensor,
+    topk_weights: torch.Tensor,
+    recv_tokens: torch.Tensor,
+    recv_topk_weights: torch.Tensor,
+) -> None:
+    """Raw dispatch; no autograd, no prepare. Caller must run ep_prepare first."""
+    tex.ep_dispatch(
+        buffer.handle_mem, topk_idx, tokens, topk_weights, recv_tokens, recv_topk_weights
+    )
+
+
+def _ep_combine_raw(buffer: "EpBuffer", expert_out: torch.Tensor, result: torch.Tensor) -> None:
+    """Raw combine; no autograd. Caller pre-weights expert_out."""
+    tex.ep_combine(buffer.handle_mem, expert_out, result)
+
+
+# autograd.Function wrappers
+
+
+class _EpDispatch(torch.autograd.Function):
+    """Autograd prepare+dispatch; bwd uses user-supplied grad inputs as-is."""
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        handle_mem: torch.Tensor,
+        top_k: int,
+        alignment: int,
+        recv_tokens: torch.Tensor,
+        recv_topk_weights: torch.Tensor,
+        token_counts: torch.Tensor,
+        topk_idx: torch.Tensor,
+        tokens: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ):
+        """Prepare + dispatch fwd."""
+        torch.ops.transformer_engine_ep.prepare(
+            handle_mem, top_k, topk_idx, token_counts, alignment
+        )
+        torch.ops.transformer_engine_ep.dispatch(
+            handle_mem,
+            topk_idx,
+            tokens,
+            topk_weights,
+            recv_tokens,
+            recv_topk_weights,
+        )
+        ctx.save_for_backward(handle_mem)
+        ctx.tokens_shape = tokens.shape
+        ctx.tokens_dtype = tokens.dtype
+        ctx.topk_weights_shape = topk_weights.shape
+        ctx.tokens_T_flat = tokens.numel() // tokens.shape[-1]
+        ctx.topk_T_flat = topk_weights.numel() // topk_weights.shape[-1]
+        ctx.top_k = topk_weights.shape[-1]
+        ctx.recv_capacity = recv_tokens.shape[0]
+        ctx.hidden_dim = tokens.shape[-1]
+        ctx.mark_non_differentiable(token_counts)
+        # Detach so the long-lived buffers aren't tracked as differentiable outputs;
+        # autograd re-attaches grad_fn pointing back at this Function.
+        return recv_tokens.detach(), recv_topk_weights.detach(), token_counts
+
+    @staticmethod
+    def backward(ctx, g_recv_tokens, g_recv_topk_weights, _g_token_counts):  # type: ignore[override]
+        """Dispatch bwd; normalizes grad-input layout, otherwise passes through."""
+        (handle_mem,) = ctx.saved_tensors
+        device = handle_mem.device
+        g_recv_tokens = g_recv_tokens.contiguous()
+        g_recv_topk_weights = g_recv_topk_weights.contiguous()
+        grad_tokens = torch.empty(
+            ctx.tokens_T_flat, ctx.hidden_dim, dtype=ctx.tokens_dtype, device=device
+        )
+        grad_topk_weights = torch.empty(
+            ctx.topk_T_flat, ctx.top_k, dtype=torch.float32, device=device
+        )
+        torch.ops.transformer_engine_ep.dispatch_bwd(
+            handle_mem,
+            g_recv_tokens,
+            g_recv_topk_weights,
+            grad_tokens,
+            grad_topk_weights,
+        )
+        return (
+            None,  # handle_mem
+            None,  # top_k
+            None,  # alignment
+            None,  # recv_tokens
+            None,  # recv_topk_weights
+            None,  # token_counts
+            None,  # topk_idx
+            grad_tokens.view(ctx.tokens_shape),
+            grad_topk_weights.view(ctx.topk_weights_shape),
+        )
+
+
+class _EpCombine(torch.autograd.Function):
+    """Autograd combine.
+
+    bwd scatters the expert_out grad into ``grad_symm_buf`` (EpBuffer-owned
+    symm-mem, one-sided) in zero-copy mode, or into a plain tensor allocated
+    in-flight here otherwise. The latter keeps allocation torch.compile /
+    CUDA-graph safe and lets autograd own the grad's lifetime.
+
+    ``grad_symm_buf`` is the backward's scatter target (an output it writes, never
+    reads), so it is stashed as a plain ctx attribute rather than via
+    save_for_backward, which would version-track a tensor we mutate.
+    """
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        handle_mem: torch.Tensor,
+        num_local_tokens: int,
+        hidden_dim: int,
+        grad_symm_buf: Optional[torch.Tensor],
+        expert_out: torch.Tensor,
+    ):
+        """Combine fwd; stashes the bwd grad target or expert_out shape to size it."""
+        device = expert_out.device
+        result = torch.empty(num_local_tokens, hidden_dim, dtype=expert_out.dtype, device=device)
+        torch.ops.transformer_engine_ep.combine(handle_mem, expert_out, result)
+        ctx.save_for_backward(handle_mem)
+        ctx.grad_symm_buf = grad_symm_buf
+        if grad_symm_buf is None:
+            ctx.expert_out_shape = expert_out.shape
+            ctx.expert_out_dtype = expert_out.dtype
+            ctx.device = device
+        return result
+
+    @staticmethod
+    def backward(ctx, g_result):  # type: ignore[override]
+        """Combine bwd; scatters the result grad into the grad target."""
+        if not g_result.is_contiguous():
+            g_result = g_result.contiguous()
+        (handle_mem,) = ctx.saved_tensors
+        grad_expert_out = ctx.grad_symm_buf
+        if grad_expert_out is None:
+            grad_expert_out = torch.empty(
+                ctx.expert_out_shape, dtype=ctx.expert_out_dtype, device=ctx.device
+            )
+        torch.ops.transformer_engine_ep.combine_bwd(handle_mem, g_result, grad_expert_out)
+        return (
+            None,  # handle_mem
+            None,  # num_local_tokens
+            None,  # hidden_dim
+            None,  # grad_symm_buf
+            grad_expert_out,
+        )
+
+
+# Public high-level wrappers
+
+
+# NCCL EP currently only supports bfloat16 payload tensors.
+def _require_bf16(name: str, t: torch.Tensor) -> None:
+    if t.dtype is not torch.bfloat16:
+        raise NotImplementedError(
+            f"NCCL EP currently supports only bfloat16 payloads; got {name}.dtype={t.dtype}."
+        )
+
+
+def ep_dispatch(
+    buffer: EpBuffer,
+    tokens: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+):
+    """Prepare + dispatch with autograd. topk_idx must be int64.
+
+    recv_tokens comes from the EpBuffer (caller-supplied or buffer-owned under
+    zero-copy) or is allocated in-flight (normal mode). recv_topk_weights is always
+    owned by the buffer. Returns (recv_tokens, recv_topk_weights, token_counts);
+    token_counts is non-diff.
+    """
+    _require_bf16("tokens", tokens)
+    if topk_weights.dtype is not torch.float32:
+        raise TypeError(
+            f"topk_weights must be float32; got dtype={topk_weights.dtype}. "
+            "Cast with topk_weights.float() before calling."
+        )
+    recv_tokens = buffer.recv_tokens_symm_buf
+    if recv_tokens is None:
+        recv_tokens = torch.empty(
+            buffer.recv_capacity_per_rank,
+            buffer.hidden_dim,
+            dtype=buffer.payload_dtype,
+            device=buffer.device,
+        )
+    recv_topk_weights = (
+        buffer.recv_topk_weights_symm_buf
+        if buffer.zero_copy
+        else torch.empty(buffer.recv_capacity_per_rank, dtype=torch.float32, device=buffer.device)
+    )
+    return _EpDispatch.apply(
+        buffer.handle_mem,
+        buffer.top_k,
+        buffer.alignment,
+        recv_tokens,
+        recv_topk_weights,
+        buffer.token_counts,
+        topk_idx,
+        tokens,
+        topk_weights,
+    )
+
+
+def ep_combine(
+    buffer: EpBuffer,
+    expert_out: torch.Tensor,
+    *,
+    num_local_tokens: Optional[int] = None,
+):
+    """Combine with autograd; caller pre-applies topk weighting.
+
+    The backward scatters the expert_out grad into the EpBuffer grad target
+    (caller-supplied or buffer-owned under zero-copy), or a tensor allocated
+    in-flight (normal mode). Result shape is (num_local_tokens, buffer.hidden_dim);
+    defaults to buffer.max_tokens_per_rank rows.
+    """
+    _require_bf16("expert_out", expert_out)
+    if num_local_tokens is None:
+        num_local_tokens = buffer.max_tokens_per_rank
+    grad_expert_out = buffer.grad_expert_out_symm_buf
+    return _EpCombine.apply(
+        buffer.handle_mem,
+        num_local_tokens,
+        buffer.hidden_dim,
+        grad_expert_out,
+        expert_out,
+    )

--- a/transformer_engine/pytorch/module/grouped_linear.py
+++ b/transformer_engine/pytorch/module/grouped_linear.py
@@ -431,6 +431,8 @@ class _GroupedLinear(torch.autograd.Function):
             backward_override = None
         if backward_override == "high_precision":
             save_original_input = True
+        elif backward_override == "dequantized":
+            save_original_input = False
 
         num_gemms = len(m_splits)
         weights = weights_and_biases[:num_gemms]

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -289,6 +289,8 @@ def _linear_forward_impl(
     is_fsdp2 = args.is_fsdp2
     if backward_override == "high_precision":
         save_original_input = True
+    elif backward_override == "dequantized":
+        save_original_input = False
 
     # NVTX label for profiling
     nvtx_label = "transformer_engine._Linear.forward"

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -421,7 +421,9 @@ class Quantizer(abc.ABC):
 
         Returning ``None`` (the default) means the quantizer cannot be represented as
         a value opaque object and keeps identity-based equality/hashing.
-        This also means, that torch.compile will not be able to optimize the quantizer.
+        This also means that passing such a quantizer as an argument to a custom op
+        causes a graph break under torch.compile, since it cannot be baked into the
+        FX graph as a constant.
         """
         return None
 

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -408,6 +408,73 @@ class Quantizer(abc.ABC):
             "columnwise": self.columnwise_usage,
         }
 
+    # ----- Value-object identity (torch.compile opaque value support) -----
+    # A *tensorless* quantizer (one whose entire state is a handful of plain,
+    # reproducible scalars -- no live tensors, no process groups) behaves like a
+    # value: two instances with the same configuration are interchangeable. Such
+    # quantizers opt into value-based ``__eq__`` / ``__hash__`` by overriding
+    # ``_value_fields``. Quantizers that keep the default (e.g. delayed-scaling
+    # ``Float8Quantizer``, which holds live scale/amax tensors, and any custom
+    # quantizer) retain the default identity semantics.
+    #
+    # This is the eager-side half of registering the quantizer as a torch.compile
+    # *value* opaque type; the torch.compile glue (``__fx_repr__``, FX
+    # reconstruction and ``register_opaque_type``) lives in
+    # ``transformer_engine.pytorch.dynamo``.
+
+    #: Attributes shared by every quantizer that take part in value identity.
+    _BASE_VALUE_FIELDS: Tuple[str, ...] = (
+        "rowwise_usage",
+        "columnwise_usage",
+        "internal",
+        "optimize_for_gemm",
+    )
+
+    def _value_fields(self) -> Optional[Tuple[str, ...]]:
+        """Subclass-specific value-defining attribute names, or ``None``.
+
+        Returning ``None`` (the default) means the quantizer is *not* a value
+        object and keeps identity-based equality/hashing. Tensorless quantizers
+        override this to return the tuple of attribute names that, together with
+        :attr:`_BASE_VALUE_FIELDS`, fully determine their value (excluding
+        non-value state such as a deprecated amax-reduction process group).
+        """
+        return None
+
+    def _value_key(self) -> Tuple[Any, ...]:
+        """Hashable, reproducible key identifying this quantizer's value.
+
+        Only valid for value quantizers (``_value_fields()`` is not ``None``).
+        """
+        fields = self._value_fields()  # pylint: disable=assignment-from-none
+        assert fields is not None, f"{type(self).__name__} is not a value quantizer"
+        items = []
+        for name in self._BASE_VALUE_FIELDS + tuple(fields):
+            value = getattr(self, name)
+            if name == "dtype":
+                # ``DType`` is an ``IntEnum``; store the int so the key stays
+                # plain: hashable and ``repr``-reproducible for FX codegen.
+                value = int(value)
+            items.append((name, value))
+        return (type(self).__qualname__, tuple(items))
+
+    def __eq__(self, other: object) -> Any:
+        # Value quantizers compare by configuration; everything else keeps the
+        # default identity semantics (returning ``NotImplemented`` makes Python
+        # fall back to identity).
+        if self is other:
+            return True
+        if self._value_fields() is None or type(self) is not type(other):
+            return NotImplemented
+        if other._value_fields() is None:
+            return NotImplemented
+        return self._value_key() == other._value_key()
+
+    def __hash__(self) -> int:
+        if self._value_fields() is None:
+            return object.__hash__(self)
+        return hash(self._value_key())
+
 
 class QuantizedTensor(torch.Tensor):
     """Abstract base class for tensor with quantized data

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -444,6 +444,18 @@ class Quantizer(abc.ABC):
             items.append((name, value))
         return (type(self).__qualname__, tuple(items))
 
+    def _check_value_has_no_amax_reduction_group(self) -> None:
+        # The amax reduction group is not part of the value key, so a value
+        # quantizer that stores one would compare/hash equal to a groupless one
+        # and let torch.compile reuse a graph that skips the reduction. Reject it
+        # (mirrors ``__fx_repr__``); pass the group per quantize call instead.
+        if getattr(self, "amax_reduction_group", None) is not None:
+            raise TypeError(
+                f"{type(self).__name__} with a non-None amax_reduction_group cannot be "
+                "used as a value object; pass the amax reduction group per quantize call "
+                "instead of storing it on the quantizer."
+            )
+
     def __eq__(self, other: object) -> Any:
         # Value quantizers compare by configuration; everything else keeps the
         # default identity semantics (returning ``NotImplemented`` makes Python
@@ -454,11 +466,14 @@ class Quantizer(abc.ABC):
             return NotImplemented
         if other._value_fields() is None:
             return NotImplemented
+        self._check_value_has_no_amax_reduction_group()
+        other._check_value_has_no_amax_reduction_group()
         return self._value_key() == other._value_key()
 
     def __hash__(self) -> int:
         if self._value_fields() is None:
             return object.__hash__(self)
+        self._check_value_has_no_amax_reduction_group()
         return hash(self._value_key())
 
 

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -408,20 +408,6 @@ class Quantizer(abc.ABC):
             "columnwise": self.columnwise_usage,
         }
 
-    # ----- Value-object identity (torch.compile opaque value support) -----
-    # A *tensorless* quantizer (one whose entire state is a handful of plain,
-    # reproducible scalars -- no live tensors, no process groups) behaves like a
-    # value: two instances with the same configuration are interchangeable. Such
-    # quantizers opt into value-based ``__eq__`` / ``__hash__`` by overriding
-    # ``_value_fields``. Quantizers that keep the default (e.g. delayed-scaling
-    # ``Float8Quantizer``, which holds live scale/amax tensors, and any custom
-    # quantizer) retain the default identity semantics.
-    #
-    # This is the eager-side half of registering the quantizer as a torch.compile
-    # *value* opaque type; the torch.compile glue (``__fx_repr__``, FX
-    # reconstruction and ``register_opaque_type``) lives in
-    # ``transformer_engine.pytorch.dynamo``.
-
     #: Attributes shared by every quantizer that take part in value identity.
     _BASE_VALUE_FIELDS: Tuple[str, ...] = (
         "rowwise_usage",
@@ -433,11 +419,9 @@ class Quantizer(abc.ABC):
     def _value_fields(self) -> Optional[Tuple[str, ...]]:
         """Subclass-specific value-defining attribute names, or ``None``.
 
-        Returning ``None`` (the default) means the quantizer is *not* a value
-        object and keeps identity-based equality/hashing. Tensorless quantizers
-        override this to return the tuple of attribute names that, together with
-        :attr:`_BASE_VALUE_FIELDS`, fully determine their value (excluding
-        non-value state such as a deprecated amax-reduction process group).
+        Returning ``None`` (the default) means the quantizer cannot be represented as
+        a value opaque object and keeps identity-based equality/hashing.
+        This also means, that torch.compile will not be able to optimize the quantizer.
         """
         return None
 

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -24,19 +24,6 @@ from transformer_engine.pytorch.tensor._quantization_helpers import (
 )
 
 
-def _contains_process_group(value: Any) -> bool:
-    """Whether *value* is (or nests) a ``torch.distributed.ProcessGroup``.
-
-    Checks the value directly and one level of ``tuple``/``list`` nesting, which
-    covers the shapes a quantizer value field could plausibly take.
-    """
-    if isinstance(value, dist_group_type):
-        return True
-    if isinstance(value, (tuple, list)):
-        return any(_contains_process_group(item) for item in value)
-    return False
-
-
 # Custom ops that should pass through __torch_dispatch__ without unwrapping
 # QuantizedTensor subclasses (e.g. Float8Tensor). Register ops here that
 # handle quantized tensors internally.
@@ -446,18 +433,19 @@ class Quantizer(abc.ABC):
         # value key, which cannot carry live distributed state. Enforced here --
         # the single point every value-materialization path (``__eq__`` /
         # ``__hash__`` / ``__fx_repr__``) goes through -- so a custom
-        # ``__fx_repr__`` cannot bypass it. Reject any field holding a
-        # ProcessGroup (e.g. the deprecated ``amax_reduction_group``) rather than
-        # silently dropping it; pass the reduction group per quantize call.
-        for name, value in vars(self).items():
-            if _contains_process_group(value):
-                raise TypeError(
-                    f"{type(self).__name__} cannot be used as a torch.compile value "
-                    f"object: attribute {name!r} holds a torch.distributed.ProcessGroup, "
-                    "which is live distributed state and must not be baked into an FX "
-                    "graph. Pass the amax reduction group per quantize call instead of "
-                    "storing it on the quantizer."
-                )
+        # ``__fx_repr__`` cannot bypass it. The only attribute that can hold a
+        # ProcessGroup is the deprecated ``amax_reduction_group`` (a scalar group
+        # excluded from the value key); reject it rather than silently dropping
+        # it -- otherwise a stored group would compare/hash equal to a groupless
+        # quantizer. Pass the reduction group per quantize call instead.
+        if isinstance(getattr(self, "amax_reduction_group", None), dist_group_type):
+            raise TypeError(
+                f"{type(self).__name__} cannot be used as a torch.compile value "
+                "object: 'amax_reduction_group' holds a torch.distributed.ProcessGroup, "
+                "which is live distributed state and must not be baked into an FX "
+                "graph. Pass the amax reduction group per quantize call instead of "
+                "storing it on the quantizer."
+            )
 
     def _value_key(self) -> Tuple[Any, ...]:
         """Hashable, reproducible key identifying this quantizer's value.

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -16,11 +16,25 @@ from torch.utils._pytree import tree_map
 import transformer_engine_torch as tex
 
 from transformer_engine.common.recipe import Recipe
+from transformer_engine.pytorch.constants import dist_group_type
 from transformer_engine.pytorch.tensor._quantization_helpers import (
     _QuantizeFunc,
     _IdentityFunc,
     _stride_from_shape,
 )
+
+
+def _contains_process_group(value: Any) -> bool:
+    """Whether *value* is (or nests) a ``torch.distributed.ProcessGroup``.
+
+    Checks the value directly and one level of ``tuple``/``list`` nesting, which
+    covers the shapes a quantizer value field could plausibly take.
+    """
+    if isinstance(value, dist_group_type):
+        return True
+    if isinstance(value, (tuple, list)):
+        return any(_contains_process_group(item) for item in value)
+    return False
 
 
 # Custom ops that should pass through __torch_dispatch__ without unwrapping
@@ -427,6 +441,24 @@ class Quantizer(abc.ABC):
         """
         return None
 
+    def _check_value_has_no_process_group(self) -> None:
+        # A value quantizer is baked into the FX graph as a constant via its
+        # value key, which cannot carry live distributed state. Enforced here --
+        # the single point every value-materialization path (``__eq__`` /
+        # ``__hash__`` / ``__fx_repr__``) goes through -- so a custom
+        # ``__fx_repr__`` cannot bypass it. Reject any field holding a
+        # ProcessGroup (e.g. the deprecated ``amax_reduction_group``) rather than
+        # silently dropping it; pass the reduction group per quantize call.
+        for name, value in vars(self).items():
+            if _contains_process_group(value):
+                raise TypeError(
+                    f"{type(self).__name__} cannot be used as a torch.compile value "
+                    f"object: attribute {name!r} holds a torch.distributed.ProcessGroup, "
+                    "which is live distributed state and must not be baked into an FX "
+                    "graph. Pass the amax reduction group per quantize call instead of "
+                    "storing it on the quantizer."
+                )
+
     def _value_key(self) -> Tuple[Any, ...]:
         """Hashable, reproducible key identifying this quantizer's value.
 
@@ -434,6 +466,7 @@ class Quantizer(abc.ABC):
         """
         fields = self._value_fields()  # pylint: disable=assignment-from-none
         assert fields is not None, f"{type(self).__name__} is not a value quantizer"
+        self._check_value_has_no_process_group()
         items = []
         for name in self._BASE_VALUE_FIELDS + tuple(fields):
             value = getattr(self, name)
@@ -444,36 +477,21 @@ class Quantizer(abc.ABC):
             items.append((name, value))
         return (type(self).__qualname__, tuple(items))
 
-    def _check_value_has_no_amax_reduction_group(self) -> None:
-        # The amax reduction group is not part of the value key, so a value
-        # quantizer that stores one would compare/hash equal to a groupless one
-        # and let torch.compile reuse a graph that skips the reduction. Reject it
-        # (mirrors ``__fx_repr__``); pass the group per quantize call instead.
-        if getattr(self, "amax_reduction_group", None) is not None:
-            raise TypeError(
-                f"{type(self).__name__} with a non-None amax_reduction_group cannot be "
-                "used as a value object; pass the amax reduction group per quantize call "
-                "instead of storing it on the quantizer."
-            )
-
     def __eq__(self, other: object) -> Any:
         # Value quantizers compare by configuration; everything else keeps the
         # default identity semantics (returning ``NotImplemented`` makes Python
-        # fall back to identity).
+        # fall back to identity). ``_value_key`` rejects a stored ProcessGroup.
         if self is other:
             return True
         if self._value_fields() is None or type(self) is not type(other):
             return NotImplemented
         if other._value_fields() is None:
             return NotImplemented
-        self._check_value_has_no_amax_reduction_group()
-        other._check_value_has_no_amax_reduction_group()
         return self._value_key() == other._value_key()
 
     def __hash__(self) -> int:
         if self._value_fields() is None:
             return object.__hash__(self)
-        self._check_value_has_no_amax_reduction_group()
         return hash(self._value_key())
 
 

--- a/transformer_engine/pytorch/quantized_tensor.py
+++ b/transformer_engine/pytorch/quantized_tensor.py
@@ -429,15 +429,9 @@ class Quantizer(abc.ABC):
         return None
 
     def _check_value_has_no_process_group(self) -> None:
-        # A value quantizer is baked into the FX graph as a constant via its
-        # value key, which cannot carry live distributed state. Enforced here --
-        # the single point every value-materialization path (``__eq__`` /
-        # ``__hash__`` / ``__fx_repr__``) goes through -- so a custom
-        # ``__fx_repr__`` cannot bypass it. The only attribute that can hold a
-        # ProcessGroup is the deprecated ``amax_reduction_group`` (a scalar group
-        # excluded from the value key); reject it rather than silently dropping
-        # it -- otherwise a stored group would compare/hash equal to a groupless
-        # quantizer. Pass the reduction group per quantize call instead.
+        # A value quantizer cannot carry live distributed state into the FX
+        # graph; reject a stored ``amax_reduction_group`` and pass it per
+        # quantize call instead.
         if isinstance(getattr(self, "amax_reduction_group", None), dist_group_type):
             raise TypeError(
                 f"{type(self).__name__} cannot be used as a torch.compile value "

--- a/transformer_engine/pytorch/tensor/_quantization_helpers.py
+++ b/transformer_engine/pytorch/tensor/_quantization_helpers.py
@@ -83,3 +83,42 @@ def _stride_from_shape(shape: list[int]):
     for d in reversed(shape[1:]):
         rstride.append(rstride[-1] * d)
     return list(reversed(rstride))
+
+
+def safe_quantized_repr(obj, cls_name, extras=None, error=None):
+    """Metadata-only repr fallback for quantized tensors whose data cannot be
+    materialized for any reason.
+
+    Each attribute access is guarded so that ``__repr__`` never raises.
+
+    Parameters
+    ----------
+    extras : dict, optional
+        Additional plain-Python (non-tensor) attributes to include, e.g.
+        ``{"is_2D_scaled": self._is_2D_scaled}``. Values are inserted after
+        ``fp8_dtype`` and before ``shape``.
+    error : BaseException, optional
+        The exception that triggered the fallback. When given, its type and
+        message are included in the ``data=`` field so that it is visible *why*
+        the data could not be materialized.
+    """
+    parts = []
+    fp8_dtype = getattr(obj, "_fp8_dtype", None)
+    if fp8_dtype is not None:
+        parts.append(f"fp8_dtype={fp8_dtype}")
+    if extras:
+        for key, value in extras.items():
+            parts.append(f"{key}={value}")
+    try:
+        parts.append(f"shape={tuple(obj.shape)}")
+    except Exception:  # pylint: disable=broad-except
+        pass
+    try:
+        parts.append(f"dtype={obj.dtype}")
+    except Exception:  # pylint: disable=broad-except
+        pass
+    if error is not None:
+        parts.append(f"data=<unmaterialized: {type(error).__name__}: {error}>")
+    else:
+        parts.append("data=<unmaterialized>")
+    return f"{cls_name}({', '.join(parts)})"

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -14,6 +14,7 @@ import transformer_engine_torch as tex
 from transformer_engine.common.recipe import Float8BlockScaling, Recipe
 from .storage.float8_blockwise_tensor_storage import Float8BlockwiseQTensorStorage
 from ..quantized_tensor import QuantizedTensor, Quantizer
+from ..dynamo import register_value_opaque_quantizer
 from ._quantization_helpers import _IdentityFunc
 from ..constants import DType
 from ..utils import devices_match, round_up_to_nearest_multiple
@@ -68,6 +69,9 @@ class Float8BlockQuantizer(Quantizer):
         quantizer.optimize_for_gemm = self.optimize_for_gemm
 
         return quantizer
+
+    def _value_fields(self) -> Tuple[str, ...]:
+        return ("dtype", "block_len", "amax_epsilon", "force_pow_2_scales", "block_scaling_dim")
 
     def update_quantized(
         self,
@@ -209,6 +213,9 @@ class Float8BlockQuantizer(Quantizer):
 
     def _get_compatible_recipe(self) -> Union[type[Recipe], None]:
         return Float8BlockScaling
+
+
+register_value_opaque_quantizer(Float8BlockQuantizer)
 
 
 class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):

--- a/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_blockwise_tensor.py
@@ -14,7 +14,7 @@ import transformer_engine_torch as tex
 from transformer_engine.common.recipe import Float8BlockScaling, Recipe
 from .storage.float8_blockwise_tensor_storage import Float8BlockwiseQTensorStorage
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 from ..constants import DType
 from ..utils import devices_match, round_up_to_nearest_multiple
 
@@ -267,11 +267,19 @@ class Float8BlockwiseQTensor(Float8BlockwiseQTensorStorage, QuantizedTensor):
         return instance
 
     def __repr__(self, *, tensor_contents=None):
-        return (
-            f"Float8BlockwiseQTensor(fp8_dtype={self._fp8_dtype},"
-            f" is_2D_scaled={self._is_2D_scaled},"
-            f" data={self.dequantize()})"
-        )
+        try:
+            return (
+                f"Float8BlockwiseQTensor(fp8_dtype={self._fp8_dtype},"
+                f" is_2D_scaled={self._is_2D_scaled},"
+                f" data={self.dequantize()})"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(
+                self,
+                "Float8BlockwiseQTensor",
+                extras={"is_2D_scaled": self._is_2D_scaled},
+                error=exc,
+            )
 
     def quantize_(
         self,

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -389,7 +389,8 @@ class Float8CurrentScalingQuantizer(Quantizer):
 
     def _value_fields(self) -> Tuple[str, ...]:
         # ``amax_reduction_group`` is intentionally excluded: it is a deprecated
-        # process group (not a value) and is restored as ``None`` on rebuild.
+        # process group (not a value). If one is actually stored, ``__fx_repr__``
+        # raises so it can never be baked into a torch.compile graph.
         return ("dtype", "force_pow_2_scales", "amax_epsilon", "with_amax_reduction")
 
 

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -18,6 +18,7 @@ from transformer_engine.common.recipe import (
 from ..utils import canonicalize_process_group, devices_match
 from .storage.float8_tensor_storage import Float8TensorStorage, _FromFloat8Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
+from ..dynamo import register_value_opaque_quantizer
 from ._quantization_helpers import _IdentityFunc
 from ..constants import dist_group_type, DType
 
@@ -385,6 +386,14 @@ class Float8CurrentScalingQuantizer(Quantizer):
         Float8CurrentScalingQuantizer supports only rowwise all-gather
         """
         return True
+
+    def _value_fields(self) -> Tuple[str, ...]:
+        # ``amax_reduction_group`` is intentionally excluded: it is a deprecated
+        # process group (not a value) and is restored as ``None`` on rebuild.
+        return ("dtype", "force_pow_2_scales", "amax_epsilon", "with_amax_reduction")
+
+
+register_value_opaque_quantizer(Float8CurrentScalingQuantizer)
 
 
 class Float8Tensor(Float8TensorStorage, QuantizedTensor):

--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -18,7 +18,7 @@ from transformer_engine.common.recipe import (
 from ..utils import canonicalize_process_group, devices_match
 from .storage.float8_tensor_storage import Float8TensorStorage, _FromFloat8Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 from ..constants import dist_group_type, DType
 
 aten = torch.ops.aten
@@ -423,13 +423,16 @@ class Float8Tensor(Float8TensorStorage, QuantizedTensor):
     amax_reduction_group: Optional[dist_group_type] = None
 
     def __repr__(self, *, tensor_contents=None):
-        return (
-            "Float8Tensor("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"scale_inv={self._scale_inv.item()}, "
-            f"data={self.dequantize()}"
-            ")"
-        )
+        try:
+            return (
+                "Float8Tensor("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"scale_inv={self._scale_inv.item()}, "
+                f"data={self.dequantize()}"
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "Float8Tensor", error=exc)
 
     def dequantize(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -18,6 +18,7 @@ from ..constants import MXFP8_BLOCK_SCALING_SIZE, DType
 from ..utils import devices_match, round_up_to_nearest_multiple
 from .storage.mxfp8_tensor_storage import MXFP8TensorStorage, _FromMXFP8Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
+from ..dynamo import register_value_opaque_quantizer
 from ._quantization_helpers import _IdentityFunc
 
 aten = torch.ops.aten
@@ -56,6 +57,9 @@ class MXFP8Quantizer(Quantizer):
         quantizer.optimize_for_gemm = self.optimize_for_gemm
 
         return quantizer
+
+    def _value_fields(self) -> Tuple[str, ...]:
+        return ("dtype",)
 
     def update_quantized(
         self,
@@ -1058,3 +1062,6 @@ class _ReshapeFunc(torch.autograd.Function):
             )
             return dgrad, None
         return grad.view(ctx.shape), None
+
+
+register_value_opaque_quantizer(MXFP8Quantizer)

--- a/transformer_engine/pytorch/tensor/mxfp8_tensor.py
+++ b/transformer_engine/pytorch/tensor/mxfp8_tensor.py
@@ -18,7 +18,7 @@ from ..constants import MXFP8_BLOCK_SCALING_SIZE, DType
 from ..utils import devices_match, round_up_to_nearest_multiple
 from .storage.mxfp8_tensor_storage import MXFP8TensorStorage, _FromMXFP8Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 
 aten = torch.ops.aten
 
@@ -233,7 +233,10 @@ class MXFP8Tensor(MXFP8TensorStorage, QuantizedTensor):
         )
 
     def __repr__(self, *, tensor_contents=None):
-        return f"MXFP8Tensor(fp8_dtype={self._fp8_dtype}, data={self.dequantize()})"
+        try:
+            return f"MXFP8Tensor(fp8_dtype={self._fp8_dtype}, data={self.dequantize()})"
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "MXFP8Tensor", error=exc)
 
     def dequantize(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -336,7 +336,8 @@ class NVFP4Quantizer(Quantizer):
 
     def _value_fields(self) -> Tuple[str, ...]:
         # ``amax_reduction_group`` is intentionally excluded: it is a deprecated
-        # process group (not a value) and is restored as ``None`` on rebuild.
+        # process group (not a value). If one is actually stored, ``__fx_repr__``
+        # raises so it can never be baked into a torch.compile graph.
         # ``rht_matrix_random_sign_mask_t`` is derived (from
         # ``_with_random_sign_mask`` and the device) but is stored verbatim so
         # reconstruction does not need to touch the device.

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -174,6 +174,7 @@ class NVFP4Quantizer(Quantizer):
         self.nvfp4_4over6_err_mode = nvfp4_4over6_err_mode.upper()
         if self.nvfp4_4over6_err_mode not in ("MAE", "MSE"):
             raise ValueError("nvfp4_4over6_err_mode must be 'MAE' or 'MSE'.")
+        self._with_random_sign_mask = with_random_sign_mask
         self.rht_matrix_random_sign_mask_t = get_random_sign_mask_for_rht(
             with_random_sign_mask, torch.cuda.current_device()
         )

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -23,6 +23,7 @@ from ..utils import (
 
 from .storage.nvfp4_tensor_storage import NVFP4TensorStorage, _FromNVFP4Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
+from ..dynamo import register_value_opaque_quantizer
 from ._quantization_helpers import _IdentityFunc
 
 aten = torch.ops.aten
@@ -332,6 +333,30 @@ class NVFP4Quantizer(Quantizer):
 
     def _get_compatible_recipe(self) -> Union[type[Recipe], None]:
         return NVFP4BlockScaling
+
+    def _value_fields(self) -> Tuple[str, ...]:
+        # ``amax_reduction_group`` is intentionally excluded: it is a deprecated
+        # process group (not a value) and is restored as ``None`` on rebuild.
+        # ``rht_matrix_random_sign_mask_t`` is derived (from
+        # ``_with_random_sign_mask`` and the device) but is stored verbatim so
+        # reconstruction does not need to touch the device.
+        return (
+            "dtype",
+            "with_rht",
+            "with_post_rht_amax",
+            "with_2d_quantization",
+            "stochastic_rounding",
+            "row_scaled_nvfp4",
+            "nvfp4_use_4over6",
+            "nvfp4_e4m3_max",
+            "nvfp4_4over6_err_mode",
+            "_with_random_sign_mask",
+            "rht_matrix_random_sign_mask_t",
+            "with_amax_reduction",
+        )
+
+
+register_value_opaque_quantizer(NVFP4Quantizer)
 
 
 class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -23,7 +23,7 @@ from ..utils import (
 
 from .storage.nvfp4_tensor_storage import NVFP4TensorStorage, _FromNVFP4Func
 from ..quantized_tensor import QuantizedTensor, Quantizer
-from ._quantization_helpers import _IdentityFunc
+from ._quantization_helpers import _IdentityFunc, safe_quantized_repr
 
 aten = torch.ops.aten
 
@@ -409,7 +409,10 @@ class NVFP4Tensor(NVFP4TensorStorage, QuantizedTensor):
         return instance
 
     def __repr__(self, *, tensor_contents=None):
-        return f"NVFP4Tensor, data={self.dequantize()})"
+        try:
+            return f"NVFP4Tensor, data={self.dequantize()})"
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "NVFP4Tensor", error=exc)
 
     def dequantize(self, *, dtype: Optional[torch.dtype] = None) -> torch.Tensor:
         """

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -186,6 +186,16 @@ class NVFP4Quantizer(Quantizer):
         state["amax_reduction_group"] = None
         return state
 
+    def _rebuild_derived_state(self) -> None:
+        """Restore the derived ``rht_matrix`` after value-key reconstruction.
+
+        ``rht_matrix`` is a ``torch.Tensor`` built from ``_with_random_sign_mask``
+        and the device, so it cannot be part of the (hashable) value key.
+        ``_rebuild_quantizer`` calls this hook to rebuild it; the ``lru_cache`` on
+        :func:`get_rht_matrix` makes an already-seen (flag, device) a cheap hit.
+        """
+        self.rht_matrix = get_rht_matrix(self._with_random_sign_mask, torch.cuda.current_device())
+
     def update_quantized(
         self,
         src: torch.Tensor,

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -348,9 +348,9 @@ class NVFP4Quantizer(Quantizer):
     def _value_fields(self) -> Tuple[str, ...]:
         # ``amax_reduction_group`` is intentionally excluded: it is a deprecated
         # process group, not a value (``_value_key`` rejects a stored group).
-        # ``rht_matrix_random_sign_mask_t`` is derived (from
-        # ``_with_random_sign_mask`` and the device) but is stored verbatim so
-        # reconstruction does not need to touch the device.
+        # ``rht_matrix_random_sign_mask_t`` is a device-independent int derived
+        # from ``_with_random_sign_mask``; kept in the key so the rebuilt
+        # quantizer carries it without recomputation.
         return (
             "dtype",
             "with_rht",

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -347,8 +347,7 @@ class NVFP4Quantizer(Quantizer):
 
     def _value_fields(self) -> Tuple[str, ...]:
         # ``amax_reduction_group`` is intentionally excluded: it is a deprecated
-        # process group (not a value). If one is actually stored, ``__fx_repr__``
-        # raises so it can never be baked into a torch.compile graph.
+        # process group, not a value (``_value_key`` rejects a stored group).
         # ``rht_matrix_random_sign_mask_t`` is derived (from
         # ``_with_random_sign_mask`` and the device) but is stored verbatim so
         # reconstruction does not need to touch the device.

--- a/transformer_engine/pytorch/tensor/storage/float8_blockwise_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_blockwise_tensor_storage.py
@@ -12,6 +12,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType_To_Torch, DType
 
@@ -354,17 +355,25 @@ class Float8BlockwiseQTensorStorage(QuantizedTensorStorage):
             del _old_data
 
     def __repr__(self):
-        if self._rowwise_data is not None:
-            data = self.dequantize()
-            descriptor = "rowwise"
-        else:
-            data = self.dequantize()
-            descriptor = "columnwise"
-        return (
-            "Float8BlockwiseQTensorStorage("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"{descriptor}_scaled_data={data})"
-        )
+        try:
+            if self._rowwise_data is not None:
+                data = self.dequantize()
+                descriptor = "rowwise"
+            else:
+                data = self.dequantize()
+                descriptor = "columnwise"
+            return (
+                "Float8BlockwiseQTensorStorage("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"{descriptor}_scaled_data={data})"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(
+                self,
+                "Float8BlockwiseQTensorStorage",
+                extras={"is_2D_scaled": self._is_2D_scaled},
+                error=exc,
+            )
 
     def update_usage(
         self, rowwise_usage: Optional[bool] = None, columnwise_usage: Optional[bool] = None

--- a/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
@@ -12,6 +12,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType as torch_to_transformer_engine_dtype, TE_DType_To_Torch, DType
 
@@ -209,13 +210,16 @@ class Float8TensorStorage(QuantizedTensorStorage):
         )
 
     def __repr__(self):
-        return (
-            "Float8TensorStorage("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"scale_inv={self._scale_inv.item()}, "
-            f"data={self.dequantize()}"
-            ")"
-        )
+        try:
+            return (
+                "Float8TensorStorage("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"scale_inv={self._scale_inv.item()}, "
+                f"data={self.dequantize()}"
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "Float8TensorStorage", error=exc)
 
     def _create_transpose(self):
         """Update FP8 transpose cache"""

--- a/transformer_engine/pytorch/tensor/storage/mxfp8_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/mxfp8_tensor_storage.py
@@ -13,6 +13,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType as torch_to_transformer_engine_dtype, DType
 
@@ -257,15 +258,18 @@ class MXFP8TensorStorage(QuantizedTensorStorage):
         )
 
     def __repr__(self):
-        data_rowwise = self.dequantize()
+        try:
+            data_rowwise = self.dequantize()
 
-        return (
-            "MXFP8TensorStorage("
-            f"fp8_dtype={self._fp8_dtype}, "
-            f"rowwise_scaled_data={data_rowwise}"
-            f"rowwise_scale_inv={self._rowwise_scale_inv}, "
-            ")"
-        )
+            return (
+                "MXFP8TensorStorage("
+                f"fp8_dtype={self._fp8_dtype}, "
+                f"rowwise_scaled_data={data_rowwise}"
+                f"rowwise_scale_inv={self._rowwise_scale_inv}, "
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "MXFP8TensorStorage", error=exc)
 
     def update_usage(
         self,

--- a/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
@@ -16,6 +16,7 @@ import torch
 import transformer_engine_torch as tex
 
 from ...quantized_tensor import QuantizedTensorStorage, Quantizer
+from .._quantization_helpers import safe_quantized_repr
 
 from ...constants import TE_DType as torch_to_transformer_engine_dtype, DType
 from ...utils import _empty_tensor
@@ -340,16 +341,19 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
         )
 
     def __repr__(self):
-        data_rowwise = self.dequantize()
+        try:
+            data_rowwise = self.dequantize()
 
-        return (
-            "NVFP4TensorStorage("
-            f"rowwise_scaled_data={data_rowwise},"
-            f"rowwise_scale_inv={self._rowwise_scale_inv},"
-            f"amax_rowwise={self._amax_rowwise},"
-            f"amax_columnwise={self._amax_columnwise},"
-            ")"
-        )
+            return (
+                "NVFP4TensorStorage("
+                f"rowwise_scaled_data={data_rowwise},"
+                f"rowwise_scale_inv={self._rowwise_scale_inv},"
+                f"amax_rowwise={self._amax_rowwise},"
+                f"amax_columnwise={self._amax_columnwise},"
+                ")"
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            return safe_quantized_repr(self, "NVFP4TensorStorage", error=exc)
 
     def update_usage(
         self,


### PR DESCRIPTION
# Description
Tensorless quantizers in TE (MXFP8, FP8 blockwise, FP8 current-scaling, NVFP4)
are fully described by a handful of plain, reproducible scalars — they hold no
live tensors and no process groups. This PR turns them into **opaque value
objects** so `torch.compile` can treat them as baked-in constants: two
quantizers with the same configuration become interchangeable, hashable, and
reconstructible inside an FX graph.

Quantizers that hold live state (delayed-scaling `Float8Quantizer`, which keeps
`scale`/`amax` tensors) and any user-defined quantizer keep the default
identity semantics, so the change is opt-in and backward compatible. On older
PyTorch builds without the opaque-object API the registration is a graceful
no-op.

Along the way this also un-breaks the existing `test_torch_compile.py` suite:
that file lived on `main` but was never wired into CI, and its
`test_autocast_nested_custom` case (nested `te.autocast` with multiple
`CustomRecipe` instances) was failing because of the `CustomRecipe` state-caching
bug fixed here. The file is now run in CI and passes.

## Type of change
- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring


## Changes

- Add opt-in value-object identity to the base `Quantizer`
  (`_value_fields` / `_value_key` / `__eq__` / `__hash__`). Returning `None`
  from `_value_fields()` (the default) keeps identity semantics.
- New module `transformer_engine/pytorch/dynamo.py` holding the
  `torch.compile` glue: `__fx_repr__`, value-key reconstruction and
  `register_value_opaque_quantizer` (gracefully no-op without PyTorch's
  opaque-object API).
- Register `MXFP8Quantizer`, `Float8BlockQuantizer`,
  `Float8CurrentScalingQuantizer` and `NVFP4Quantizer` as value opaque types
  (the deprecated `amax_reduction_group` is never part of the value).
- Fix `CustomRecipe` state caching in `TransformerEngineBaseModule.set_meta_tensor`:
  rebuild quantizers when the `CustomRecipe` *instance* changes (e.g. nested
  `te.autocast` regions) instead of reusing the first recipe's state, since
  every `CustomRecipe` shares the `CustomRecipeState` type but carries its own
  `qfactory`. This fixes the previously-failing `test_autocast_nested_custom`.
- Enable `tests/pytorch/test_torch_compile.py` in the `L0_pytorch_unittest` QA
  suite (it existed on `main` but was never run in CI), and add the quantizer
  value-object tests to it. Bringing it into CI required fixing the existing
  `CustomRecipe` torch.compile path: the `qfactory` now dispatches on
  `QuantizerRole.tensor_type` supplied by `ToyLinear.get_quantizer_roles`.
- Guard the value-object path against a stored amax reduction group: `__fx_repr__`
  already rejects any quantizer holding a process group, and `__eq__` / `__hash__`
  now raise too. The group is excluded from the value key, so a stored group would
  otherwise compare/hash equal to a groupless quantizer and let `torch.compile`
  reuse a graph that skips the reduction. Pass the group per quantize call instead.


# Checklist:
- [x] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes