### PR TITLE
[PyTorch] Add torch.compile custom-op path for Linear

### DIFF
--- a/tests/pytorch/distributed/run_layer_with_overlap.py
+++ b/tests/pytorch/distributed/run_layer_with_overlap.py
@@ -201,6 +201,19 @@ def _parse_args(argv=None, namespace=None):
         "--use-cuda-graphs", action="store_true", default=False, help="Use CUDA Graphs."
     )
     parser.add_argument(
+        "--compile",
+        action="store_true",
+        default=False,
+        help="Wrap each layer in torch.compile (tests Userbuffers on the compiled path).",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        type=str,
+        default="default",
+        choices=["default", "reduce-overhead"],
+        help="torch.compile mode used when --compile is set.",
+    )
+    parser.add_argument(
         "--ub-cfg", type=str, default=None, help="Optional TP config yaml file input."
     )
     parser.add_argument("--ub-name", type=str, default=None, help="Optional TP layer name.")
@@ -485,6 +498,9 @@ def _train(opts):
         torch.testing.assert_close(test_param, ref_param, rtol=0.0, atol=0.0)
     dist_print("Copied parameters from test model to reference model...", debug=True)
 
+    if opts.compile and opts.use_cuda_graphs:
+        raise ValueError("--compile and --use-cuda-graphs are mutually exclusive.")
+
     # Fp8 recipe setup
     fp8_format = Format.HYBRID
     fp8_recipe = None
@@ -534,6 +550,18 @@ def _train(opts):
             loss = out.sum()
             loss.backward()
         return out
+
+    if opts.compile:
+        for i, layer in enumerate(test_model.layers):
+            # dynamic=False for now: symbolic shapes would land in an OpaqueValueBundle
+            # op arg whose hash chokes on non-nested SymInt (see run_numerics).
+            test_model.layers[i] = torch.compile(
+                layer, fullgraph=True, mode=opts.compile_mode, dynamic=False
+            )
+        dist_print(
+            f"Compiled test model layers with torch.compile (mode={opts.compile_mode})...",
+            debug=True,
+        )
 
     torch_rng_state = torch.get_rng_state()
     cuda_rng_state = torch.cuda.get_rng_state(torch.device(f"cuda:{LOCAL_RANK}"))

--- a/tests/pytorch/distributed/run_numerics.py
+++ b/tests/pytorch/distributed/run_numerics.py
@@ -310,22 +310,45 @@ def _copy_params(model_distributed, model_single):
 
 
 def _apply_models(
-    model_single_node, model_distributed, input_single_node, input_distributed, **kwargs
+    model_single_node,
+    model_distributed,
+    input_single_node,
+    input_distributed,
+    use_compile=False,
+    compile_mode="default",
+    **kwargs,
 ):
     _alloc_main_grad(model_single_node, model_distributed)  # for fuse_wgrad_accumulation=True
     input_single_node.requires_grad_()
     input_distributed.requires_grad_()
+    forward_single_node = model_single_node
+    forward_distributed = model_distributed
+    if use_compile:
+        # Each parametrized case compiles the same module.forward code object with
+        # a different shape/recipe; with dynamic=False those guards accumulate and
+        # eventually trip Dynamo's recompile_limit. Reset so every case starts from
+        # a clean compile cache (mirrors the single-GPU torch.compile tests).
+        torch._dynamo.reset()
+        # dynamic=False for now: a symbolic shape would land in an OpaqueValueBundle
+        # (value-opaque op arg) whose hash chokes on non-nested SymInt. Force static
+        # shapes (recompile per shape) until the bundle handles symbolic shapes.
+        forward_single_node = torch.compile(
+            model_single_node, fullgraph=True, mode=compile_mode, dynamic=False
+        )
+        forward_distributed = torch.compile(
+            model_distributed, fullgraph=True, mode=compile_mode, dynamic=False
+        )
     with te.autocast(
         enabled=QUANTIZATION is not None,
         recipe=quantization_recipe(),
     ):
-        output_single_node = model_single_node(input_single_node, **kwargs)
+        output_single_node = forward_single_node(input_single_node, **kwargs)
     with te.autocast(
         enabled=QUANTIZATION is not None,
         recipe=quantization_recipe(),
         amax_reduction_group=NCCL_WORLD,
     ):
-        output_distributed = model_distributed(input_distributed, **kwargs)
+        output_distributed = forward_distributed(input_distributed, **kwargs)
     return output_single_node, output_distributed
 
 
@@ -641,12 +664,20 @@ def test_quantized_all_gather():
 #                   Linear                 #
 ############################################
 @run_distributed_test()
-def _test_linear(parallel_mode=None, sequence_parallel=False, **kwargs):
+def _test_linear(
+    parallel_mode=None,
+    sequence_parallel=False,
+    use_compile=False,
+    compile_mode="default",
+    **kwargs,
+):
     """Test the linear layer with specified parallel mode and sequence parallelization.
 
     Args:
         parallel_mode (str): 'row' or 'column' parallelism.
         sequence_parallel (bool): Enable sequence parallelism if True.
+        use_compile (bool): Wrap the modules in ``torch.compile`` before running.
+        compile_mode (str): ``torch.compile`` mode ("default" or "reduce-overhead").
         kwargs (dict): Additional arguments for the linear layer.
     """
     # Set parameter data type
@@ -696,7 +727,12 @@ def _test_linear(parallel_mode=None, sequence_parallel=False, **kwargs):
 
     # Apply models
     output_single_node, output_distributed = _apply_models(
-        model_single_node, model_distributed, input_single_node, input_distributed
+        model_single_node,
+        model_distributed,
+        input_single_node,
+        input_distributed,
+        use_compile=use_compile,
+        compile_mode=compile_mode,
     )
 
     if "return_bias" in kwargs:
@@ -740,12 +776,17 @@ def test_linear():
         {"params_dtype": torch.float16 if QUANTIZATION != "nvfp4" else torch.bfloat16},
         {"delay_wgrad_compute": True},
         {"save_original_input": True},
+        {"use_compile": True},
+        {"use_compile": True, "compile_mode": "reduce-overhead"},
     ]
 
     for kwargs in kwargs_list:
         if kwargs.get("save_original_input", False) and QUANTIZATION == "fp8":
             continue
         if kwargs.get("delay_wgrad_compute", False) and NVTE_TEST_NVINSPECT_ENABLED:
+            continue
+        # debug instrumentation forces the eager fallback, so compile is a no-op there.
+        if kwargs.get("use_compile", False) and NVTE_TEST_NVINSPECT_ENABLED:
             continue
         for parallel_mode in ["column", "row"]:
             for sequence_parallel in [False, True]:

--- a/tests/pytorch/distributed/test_comm_gemm_overlap.py
+++ b/tests/pytorch/distributed/test_comm_gemm_overlap.py
@@ -111,6 +111,8 @@ def _run_layer_with_overlap(
     quantization,
     num_layers=1,
     use_cublasmp=False,
+    compile=False,
+    compile_mode="default",
 ):
     test_path = TEST_ROOT / "run_layer_with_overlap.py"
     test_cmd = LAUNCH_CMD + [
@@ -128,6 +130,10 @@ def _run_layer_with_overlap(
 
     if overlap_rs_dgrad:
         test_cmd.append("--overlap-rs-dgrad")
+
+    if compile:
+        test_cmd.append("--compile")
+        test_cmd.append(f"--compile-mode={compile_mode}")
 
     if fp8:
         if quantization in ("fp8_delayed_scaling", "fp8_current_scaling") and not fp8_available:
@@ -278,6 +284,40 @@ def test_layers_with_overlap_bf16(
     """
     _run_layer_with_overlap(
         layer_type, linear_parallel_mode, overlap_rs_dgrad, fp8, None, use_cublasmp=use_cublasmp
+    )
+
+
+@pytest.mark.parametrize("compile_mode", ["default", "reduce-overhead"])
+@pytest.mark.parametrize(
+    "linear_parallel_mode,overlap_rs_dgrad",
+    [
+        ("row", False),
+        ("column", False),
+        ("column", True),
+    ],
+    ids=[
+        "ROW-PARALLEL",
+        "COL-PARALLEL - BULK DGRAD/WGRAD",
+        "COL-PARALLEL - DGRAD+RS",
+    ],
+)
+def test_linear_with_overlap_compile(linear_parallel_mode, overlap_rs_dgrad, compile_mode):
+    """te.Linear comm+GEMM overlap (Userbuffers) under torch.compile (BF16).
+
+    Userbuffers is expected to stay on Linear's compiled custom-op path (the
+    collective lives inside the opaque op), so this checks that torch.compile +
+    Userbuffers stays numerically correct against the eager, non-overlap reference.
+    ``compile_mode="reduce-overhead"`` additionally exercises CUDA-graph trees on
+    top of the Userbuffers collectives.
+    """
+    _run_layer_with_overlap(
+        te.Linear.__name__,
+        linear_parallel_mode,
+        overlap_rs_dgrad,
+        False,
+        None,
+        compile=True,
+        compile_mode=compile_mode,
     )
 
 

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -31,6 +31,7 @@ from transformer_engine.pytorch.tensor.float8_tensor import Float8CurrentScaling
 from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
 from transformer_engine.pytorch.quantized_tensor import QuantizedTensor, _STORAGE_REGISTRY
 from transformer_engine.pytorch.dynamo import TensorProto, to_tensor_proto
+from transformer_engine.pytorch.quantization import QuantizerRole
 from transformer_engine.pytorch import (
     is_fp8_available,
     is_mxfp8_available,

--- a/tests/pytorch/test_torch_compile.py
+++ b/tests/pytorch/test_torch_compile.py
@@ -3,9 +3,11 @@
 # See LICENSE for license information.
 
 import abc
+import contextlib
 
 import pytest
 import torch
+from torch._dynamo.utils import counters
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 
 try:
@@ -31,7 +33,6 @@ from transformer_engine.pytorch.tensor.float8_tensor import Float8CurrentScaling
 from transformer_engine.pytorch.tensor.nvfp4_tensor import NVFP4Quantizer
 from transformer_engine.pytorch.quantized_tensor import QuantizedTensor, _STORAGE_REGISTRY
 from transformer_engine.pytorch.dynamo import TensorProto, to_tensor_proto
-from transformer_engine.pytorch.quantization import QuantizerRole
 from transformer_engine.pytorch import (
     is_fp8_available,
     is_mxfp8_available,
@@ -86,6 +87,75 @@ if nvfp4_available:
     _all_recipes.append(recipe.NVFP4BlockScaling())
     _all_recipes.append(nvfp4_4over6())
     _all_recipes.append(nvfp4_row_scaled())
+
+
+# torch.compile modes exercised by the te.Linear tests: the default backend and
+# "reduce-overhead" (CUDA-graph trees), to ensure the custom-op path is
+# CUDA-graph capturable.
+_compile_modes = ["default", "reduce-overhead"]
+
+
+def _cudagraph_warmup(fn, inp, *, backward: bool) -> None:
+    """
+    Force TE's lazily-created global scratch to be allocated before capture.
+    """
+    out = fn(inp)
+    if backward:
+        out.sum().backward()
+
+
+@contextlib.contextmanager
+def _assert_no_cudagraph_skips(enabled: bool):
+    """Assert ``torch.compile(mode="reduce-overhead")`` actually captured CUDA
+    graphs for every graph instead of silently running it eagerly.
+
+    Inductor bumps ``counters["inductor"]["cudagraph_skips"]`` whenever it
+    declines to capture a cudagraph (input mutation, CPU scalars, cudagraph-unsafe
+    ops, ...) and falls back to eager for that graph. ``fullgraph=True`` only rules
+    out *dynamo* graph breaks, not these *inductor*-level skips, so this guards that
+    the reduce-overhead path didn't degrade to eager. No-op when ``enabled`` is
+    False (e.g. the default backend, where cudagraphs don't apply).
+    """
+    before = counters["inductor"]["cudagraph_skips"]
+    yield
+    if enabled:
+        skipped = counters["inductor"]["cudagraph_skips"] - before
+        assert skipped == 0, (
+            f"reduce-overhead fell back to eager: {skipped} cudagraph skip(s); "
+            "see the 'skipping cudagraphs due to ...' log for the reason"
+        )
+
+
+# bf16 output tolerance: eager and compiled run the same kernels, so they should
+# agree closely; the slack only absorbs reduction-order / cuda-graph differences.
+_EAGER_ATOL, _EAGER_RTOL = 1e-2, 1.6e-2
+
+
+def _assert_close_eager_compiled(fn, compiled, model, base):
+    """Run ``fn`` eagerly and ``compiled`` on identical inputs; assert the
+    forward output and the input / weight gradients match.
+
+    Guards the compiled custom-op path against silently diverging from eager
+    execution -- a wrong-but-same-shape result would slip past shape / grad
+    presence checks alone.
+    """
+    inp_eager = base.detach().clone().requires_grad_(True)
+    model.zero_grad(set_to_none=True)
+    out_eager = fn(inp_eager)
+    out_eager.sum().backward()
+    ref_out = out_eager.detach().clone()
+    ref_wgrad = model.weight.grad.detach().clone()
+    ref_igrad = inp_eager.grad.detach().clone()
+
+    inp_compiled = base.detach().clone().requires_grad_(True)
+    model.zero_grad(set_to_none=True)
+    # Clone before a later cuda-graph replay overwrites the static output buffer.
+    out_compiled = compiled(inp_compiled).clone()
+    out_compiled.sum().backward()
+
+    torch.testing.assert_close(out_compiled, ref_out, atol=_EAGER_ATOL, rtol=_EAGER_RTOL)
+    torch.testing.assert_close(inp_compiled.grad, ref_igrad, atol=_EAGER_ATOL, rtol=_EAGER_RTOL)
+    torch.testing.assert_close(model.weight.grad, ref_wgrad, atol=_EAGER_ATOL, rtol=_EAGER_RTOL)
 
 
 # ---------------------------------------------------------------------------
@@ -724,9 +794,13 @@ def test_tensor_proto_matches_primitives(factory, shape):
     # Metadata matches the quantizer's.
     assert proto.create_metadata() == q.create_metadata(shape, dtype=torch.bfloat16)
 
-    # inner_names + create_inner_tensors match _describe_buffers.
+    # inner_names follows the storage's canonical __tensor_flatten__ order (the
+    # order the real op flattens its outputs to), while create_inner_tensors
+    # matches the _describe_buffers geometry (a name->shape/dtype mapping).
     bufs = q._describe_buffers(shape)  # pylint: disable=protected-access
-    names = tuple(bufs)
+    direct = _build_from_primitives(q, shape, torch.bfloat16)
+    names = tuple(direct.__tensor_flatten__()[0])
+    assert set(names) == set(bufs)
     assert proto.inner_names() == names
     inner = proto.create_inner_tensors()
     assert len(inner) == len(names)
@@ -736,7 +810,6 @@ def test_tensor_proto_matches_primitives(factory, shape):
         assert buf.dtype == exp_dtype
 
     # The assembled tensor matches one built directly from the primitives.
-    direct = _build_from_primitives(q, shape, torch.bfloat16)
     assert _signature(proto.create_tensor(), names) == _signature(direct, names)
 
 
@@ -816,4 +889,266 @@ def test_to_tensor_proto_quantized(factory, shape):
     # Rebuilding from the derived proto matches the original tensor's structure.
     assert _signature(proto.create_tensor(), proto.inner_names()) == _signature(
         tensor, proto.inner_names()
+    )
+
+
+# ---------------------------------------------------------------------------
+# te.Linear
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _opaque_available, reason="torch opaque object API not available")
+@pytest.mark.parametrize("compile_mode", _compile_modes)
+@pytest.mark.parametrize(
+    "fp8_recipe",
+    [None, *_all_recipes],
+    ids=lambda r: "bf16" if r is None else type(r).__name__,
+)
+def test_te_linear_compiles(fp8_recipe, compile_mode):
+    """
+    torch.compile(fullgraph=True) of ``te.Linear`` under every built-in
+    recipe (plus the bf16-only baseline with no autocast), for both the default
+    backend and ``mode="reduce-overhead"`` (CUDA-graph trees).
+    """
+    if fp8_recipe is not None and not fp8_available:
+        pytest.skip(reason_for_no_fp8)
+
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    # FP8 GEMMs require leading dimensions divisible by 16.
+    model = te.Linear(64, 32, params_dtype=dtype, device=device)
+
+    def fn(inp):
+        if fp8_recipe is None:
+            return model(inp)
+        with te.autocast(recipe=fp8_recipe):
+            return model(inp)
+
+    torch._dynamo.reset()
+    if compile_mode == "reduce-overhead":
+        _cudagraph_warmup(
+            fn,
+            torch.randn(32, 64, dtype=dtype, device=device, requires_grad=True),
+            backward=True,
+        )
+        model.zero_grad(set_to_none=True)
+    compiled = torch.compile(fn, fullgraph=True, mode=compile_mode)
+
+    # ``reduce-overhead`` warms up on the first call(s) and replays a captured
+    # CUDA graph afterwards, so iterate a few times to actually exercise replay.
+    n_iters = 3 if compile_mode == "reduce-overhead" else 1
+    with _assert_no_cudagraph_skips(compile_mode == "reduce-overhead"):
+        for _ in range(n_iters):
+            base = torch.randn(32, 64, dtype=dtype, device=device)
+            _assert_close_eager_compiled(fn, compiled, model, base)
+
+
+@pytest.mark.skipif(not _opaque_available, reason="torch opaque object API not available")
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize("compile_mode", _compile_modes)
+def test_te_linear_compile_with_quantized_fp8_weight(compile_mode):
+    """torch.compile should handle Linear weights initialized as FP8 tensors,
+    for both the default backend and ``mode="reduce-overhead"``.
+
+    Exercises the two-tier op + ``register_torch_dispatch`` flattening of a
+    ``Float8Tensor`` weight *input* in
+    :mod:`transformer_engine.pytorch.dynamo`.
+    """
+    dtype = torch.bfloat16
+    device = "cuda"
+    fp8_recipe = recipe.Float8CurrentScaling()
+
+    with te.quantized_model_init(enabled=True, recipe=fp8_recipe):
+        model = te.Linear(64, 32, params_dtype=dtype, device=device)
+
+    assert isinstance(model.weight, te.Float8Tensor)
+
+    def fn(inp):
+        with te.autocast(recipe=fp8_recipe):
+            return model(inp)
+
+    torch._dynamo.reset()
+    if compile_mode == "reduce-overhead":
+        _cudagraph_warmup(
+            fn,
+            torch.randn(32, 64, dtype=dtype, device=device, requires_grad=True),
+            backward=True,
+        )
+        model.zero_grad(set_to_none=True)
+    compiled = torch.compile(fn, fullgraph=True, mode=compile_mode)
+
+    n_iters = 3 if compile_mode == "reduce-overhead" else 1
+    with _assert_no_cudagraph_skips(compile_mode == "reduce-overhead"):
+        for _ in range(n_iters):
+            base = torch.randn(32, 64, dtype=dtype, device=device)
+            _assert_close_eager_compiled(fn, compiled, model, base)
+
+
+@pytest.mark.skipif(not _opaque_available, reason="torch opaque object API not available")
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize("compile_mode", _compile_modes)
+def test_te_linear_compile_with_fp8_output(compile_mode):
+    """torch.compile of ``te.Linear(..., fp8_output=True)`` without gradient:
+    forward returns a :class:`Float8Tensor`. Covers the default backend and
+    ``mode="reduce-overhead"``.
+
+    Exercises the output-rewrap path in
+    :mod:`transformer_engine.pytorch.dynamo`: when an output quantizer is
+    active, the op returns the flat inner data tensors and the framework
+    rewraps them into a ``Float8Tensor`` via ``__tensor_unflatten__``. A
+    differentiable FP8 output is unsupported under compile (``Linear.forward``
+    falls back to eager), so this test covers the supported case: an FP8 output
+    that does not require grad (inference / ``torch.no_grad``).
+    """
+    dtype = torch.bfloat16
+    device = "cuda"
+    fp8_recipe = recipe.Float8CurrentScaling()
+
+    model = te.Linear(64, 32, params_dtype=dtype, device=device)
+
+    def fn(inp):
+        with te.autocast(recipe=fp8_recipe):
+            return model(inp, fp8_output=True)
+
+    torch._dynamo.reset()
+    if compile_mode == "reduce-overhead":
+        with torch.no_grad():
+            _cudagraph_warmup(fn, torch.randn(32, 64, dtype=dtype, device=device), backward=False)
+    compiled = torch.compile(fn, fullgraph=True, mode=compile_mode)
+
+    n_iters = 3 if compile_mode == "reduce-overhead" else 1
+    with _assert_no_cudagraph_skips(compile_mode == "reduce-overhead"):
+        for _ in range(n_iters):
+            inp = torch.randn(32, 64, dtype=dtype, device=device)
+            with torch.no_grad():
+                out_eager = fn(inp)
+                out = compiled(inp)
+            assert isinstance(
+                out, te.Float8Tensor
+            ), f"expected Float8Tensor output, got {type(out).__name__}"
+            assert out.shape == (32, 32)
+            assert (
+                out._quantizer is not None
+            ), "FP8 output lost its quantizer on the torch.compile path"
+            # The rewrap rebuilt a fully-functional Float8Tensor: dequantizing it
+            # outside the compiled region exercises scale + data + dtype wiring.
+            deq = out.dequantize()
+            assert deq.shape == (32, 32)
+            assert deq.dtype == dtype
+            # Compiled FP8 output must match the eager FP8 output value-wise.
+            torch.testing.assert_close(
+                deq, out_eager.dequantize(), atol=_EAGER_ATOL, rtol=_EAGER_RTOL
+            )
+
+
+@pytest.mark.skipif(not _opaque_available, reason="torch opaque object API not available")
+@pytest.mark.skipif(not fp8_available, reason=reason_for_no_fp8)
+@pytest.mark.parametrize("compile_mode", _compile_modes)
+def test_te_linear_compile_is_first_microbatch(compile_mode):
+    """torch.compile of ``te.Linear`` across a multi-step microbatch schedule that
+    drives FP8 weight caching via ``is_first_microbatch``, for the default backend
+    and ``mode="reduce-overhead"`` (CUDA-graph trees).
+
+    ``is_first_microbatch=True`` quantizes and caches the FP8 weight; subsequent
+    ``False`` steps must reuse the cached FP8 weight instead of re-quantizing. This
+    exercises that cache path under compile and checks it stays numerically aligned
+    with eager. ``is_first_microbatch`` is a Python bool, so each distinct value is
+    its own dynamo guard/graph.
+    """
+    dtype = torch.bfloat16
+    device = "cuda"
+    fp8_recipe = recipe.Float8CurrentScaling()
+    model = te.Linear(64, 32, params_dtype=dtype, device=device)
+
+    # First microbatch caches the FP8 weight, the rest reuse the cache.
+    schedule = [True, False, False]
+    is_first = schedule[0]  # rebound each step; closed over by ``fn``.
+
+    def fn(inp):
+        with te.autocast(recipe=fp8_recipe):
+            return model(inp, is_first_microbatch=is_first)
+
+    torch._dynamo.reset()
+    if compile_mode == "reduce-overhead":
+        _cudagraph_warmup(
+            fn,
+            torch.randn(32, 64, dtype=dtype, device=device, requires_grad=True),
+            backward=True,
+        )
+        model.zero_grad(set_to_none=True)
+    compiled = torch.compile(fn, fullgraph=True, mode=compile_mode)
+
+    with _assert_no_cudagraph_skips(compile_mode == "reduce-overhead"):
+        for is_first in schedule:
+            base = torch.randn(32, 64, dtype=dtype, device=device)
+            _assert_close_eager_compiled(fn, compiled, model, base)
+
+
+@pytest.mark.skipif(not _opaque_available, reason="torch opaque object API not available")
+def test_te_linear_dynamic_shapes():
+    """torch.compile(dynamic=True) of ``te.Linear`` with varying batch sizes.
+
+    Verifies that the compiled graph handles symbolic (dynamic) leading
+    dimensions without graph breaks or recompilations after the initial trace.
+    Key correctness property: a graph compiled for batch=16 must produce
+    numerically correct results for batch=32 without triggering a recompile.
+
+    This exercises two fixes for dynamic shapes:
+    1. ``_linear_setup_ctx`` no longer stores ``inp_shape`` in the value bundle
+       (torch.Size with SymInt dims is not hashable in OpaqueValueBundle).
+    2. ``_linear_backward_impl_fake`` derives dgrad shape from grad_output +
+       weight + SP config instead of relying on the stored ``inp_shape``.
+    3. ``_linear_backward`` reconstructs ``inp_shape`` on-the-fly from the same
+       tensor sources when it is None (compiled mode).
+
+    FP8 + dynamic=True is tracked separately (requires resolving
+    ``UnsafeScriptObjectError`` for TorchScript quantizer objects with Dynamo).
+    """
+    dtype = torch.bfloat16
+    device = "cuda"
+    in_features, out_features = 64, 32
+    model = te.Linear(in_features, out_features, params_dtype=dtype, device=device)
+
+    def fn(inp):
+        return model(inp)
+
+    torch._dynamo.reset()
+    compiled = torch.compile(fn, fullgraph=True)
+
+    batch_sizes = [16, 32, 48]
+
+    for i, batch in enumerate(batch_sizes):
+        inp = torch.randn(batch, in_features, dtype=dtype, device=device, requires_grad=True)
+        # Mark batch dim as dynamic so Dynamo traces once and reuses across batch sizes.
+        torch._dynamo.mark_dynamic(inp, 0)
+        out = compiled(inp)
+        assert out.shape == (batch, out_features), f"wrong output shape for batch={batch}"
+        out.sum().backward()
+        assert inp.grad is not None, f"no input gradient for batch={batch}"
+        assert inp.grad.shape == inp.shape, f"wrong grad shape for batch={batch}"
+
+        # Verify numerics against eager on each distinct batch size.
+        inp_eager = inp.detach().clone().requires_grad_(True)
+        model.zero_grad(set_to_none=True)
+        out_eager = model(inp_eager)
+        out_eager.sum().backward()
+        torch.testing.assert_close(
+            out.detach(), out_eager.detach(), atol=_EAGER_ATOL, rtol=_EAGER_RTOL,
+            msg=f"forward mismatch at batch={batch}",
+        )
+        torch.testing.assert_close(
+            inp.grad, inp_eager.grad, atol=_EAGER_ATOL, rtol=_EAGER_RTOL,
+            msg=f"dgrad mismatch at batch={batch}",
+        )
+
+        if i == 0:
+            # After the first (tracing) call, record the recompile counter
+            # baseline -- subsequent batch sizes must not trigger recompiles.
+            recompile_count_baseline = counters["stats"].get("recompile_reasons", 0)
+
+    recompile_count_after = counters["stats"].get("recompile_reasons", 0)
+    assert recompile_count_after == recompile_count_baseline, (
+        f"Unexpected recompilation(s) across different batch sizes: "
+        f"{recompile_count_after - recompile_count_baseline} recompile(s) detected"
     )

--- a/transformer_engine/pytorch/dynamo/__init__.py
+++ b/transformer_engine/pytorch/dynamo/__init__.py
@@ -6,10 +6,12 @@
 
 from .quantizer_opaque import register_value_opaque_quantizer, is_value_opaque_quantizer
 from .tensor_proto import TensorProto, to_tensor_proto
+from .custom_op import register_custom_op
 
 __all__ = [
     "register_value_opaque_quantizer",
     "is_value_opaque_quantizer",
     "TensorProto",
     "to_tensor_proto",
+    "register_custom_op",
 ]

--- a/transformer_engine/pytorch/dynamo/custom_op.py
+++ b/transformer_engine/pytorch/dynamo/custom_op.py
@@ -35,7 +35,6 @@ from ..quantized_tensor import (
 )
 
 _TE_OP_NAMESPACE = "transformer_engine_compile"
-_TE_LIB = torch.library.Library(_TE_OP_NAMESPACE, "FRAGMENT")  # noqa: TOR901
 
 
 # ``None`` entries in an op's flat ``Tensor[]`` return are smuggled through a
@@ -939,7 +938,7 @@ def _resolve_grad_targets(
 def _register_kernel(
     *,
     op_name: str,
-    op_qualname: str,
+    schema_str: str,
     arg_type: type,
     arg_names: List[str],
     buckets: List[_Bucket],
@@ -947,8 +946,9 @@ def _register_kernel(
     impl: Callable[[Any], Any],
     fake_impl: Callable[[Any], Any],
     format_result: Callable[[Any], List[torch.Tensor]],
-) -> None:
-    """Wire the real ``impl`` + the ``fake_impl`` (proto) into the library.
+) -> Any:
+    """Define the op via ``torch.library.custom_op`` with the real ``impl`` + the
+    ``fake_impl`` (proto), returning the ``CustomOpDef``.
 
     The real kernel rebuilds the dataclass and runs ``impl``; the fake kernel
     runs the proto fake impl on the :func:`_proto_view`. Both go through
@@ -966,13 +966,16 @@ def _register_kernel(
         proto_obj = _proto_view(obj, tensor_field_names)
         return format_result(fake_impl(proto_obj))
 
-    _TE_LIB.impl(op_name, _impl, "CompositeExplicitAutograd")
-    torch.library.register_fake(op_qualname, _fake, lib=_TE_LIB)
+    op = torch.library.custom_op(
+        f"{_TE_OP_NAMESPACE}::{op_name}", _impl, mutates_args=(), schema=schema_str
+    )
+    op.register_fake(_fake)
+    return op
 
 
 def _register_autograd_for_op(
     *,
-    fwd_op_name: str,
+    fwd_op: Any,
     bwd_op_name: str,
     fwd_arg_type: type,
     fwd_arg_names: List[str],
@@ -992,7 +995,6 @@ def _register_autograd_for_op(
     templates, reassembles each flat output chunk, and hands the saved tuple +
     ``ctx_attrs`` to the module's ``setup_context``.
     """
-    fwd_qualname = f"{_TE_OP_NAMESPACE}::{fwd_op_name}"
 
     def _setup_context(ctx, inputs, output):
         ctx._te_fwd_tensor_list_lengths = {
@@ -1054,12 +1056,7 @@ def _register_autograd_for_op(
             out[pos] = g
         return tuple(out)
 
-    torch.library.register_autograd(
-        fwd_qualname,
-        _autograd_backward,
-        setup_context=_setup_context,
-        lib=_TE_LIB,
-    )
+    fwd_op.register_autograd(_autograd_backward, setup_context=_setup_context)
 
 
 def _collect_universal_slot_offsets(buckets: List[_Bucket]) -> List[int]:
@@ -1093,12 +1090,14 @@ def _flatten_subclass_into_slots(
 def _register_outer_forwarder(
     *,
     outer_op_name: str,
+    schema_str: str,
     inner_op_name: str,
     buckets: Optional[List[_Bucket]] = None,
     subclass_list: Optional[List[type]] = None,
-) -> None:
-    """Register the outer op's default kernel + fake: forward to the inner op,
-    optionally flattening registered subclass inputs in place first.
+) -> Any:
+    """Define the outer op via ``torch.library.custom_op``: forward to the inner
+    op, optionally flattening registered subclass inputs in place first. Returns
+    the ``CustomOpDef``.
     """
     inner_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), inner_op_name)
     input_flatten_enabled = bool(subclass_list) and buckets is not None
@@ -1112,8 +1111,11 @@ def _register_outer_forwarder(
             _flatten_subclass_into_slots(new_args, slot_offsets, sub)
         return inner_op(*new_args)
 
-    _TE_LIB.impl(outer_op_name, _forward, "CompositeExplicitAutograd")
-    torch.library.register_fake(f"{_TE_OP_NAMESPACE}::{outer_op_name}", _forward, lib=_TE_LIB)
+    op = torch.library.custom_op(
+        f"{_TE_OP_NAMESPACE}::{outer_op_name}", _forward, mutates_args=(), schema=schema_str
+    )
+    op.register_fake(_forward)
+    return op
 
 
 def _all_quantized_tensor_subclasses() -> List[type]:
@@ -1208,19 +1210,14 @@ def _register_custom_op_impl(
         fwd_buckets, fwd_arg_type, input_tensors_for_grad
     )
 
-    _TE_LIB.define(f"{inner_fwd_name}{fwd_schema_args} -> Tensor[]")
-    _TE_LIB.define(f"{inner_bwd_name}{bwd_schema_args} -> Tensor[]")
-    _TE_LIB.define(f"{outer_fwd_name}{fwd_schema_args} -> Tensor[]")
-    _TE_LIB.define(f"{outer_bwd_name}{bwd_schema_args} -> Tensor[]")
+    fwd_schema = f"{fwd_schema_args} -> Tensor[]"
+    bwd_schema = f"{bwd_schema_args} -> Tensor[]"
 
-    inner_fwd_qualname = f"{_TE_OP_NAMESPACE}::{inner_fwd_name}"
     inner_bwd_qualname = f"{_TE_OP_NAMESPACE}::{inner_bwd_name}"
-    outer_fwd_qualname = f"{_TE_OP_NAMESPACE}::{outer_fwd_name}"
-    outer_bwd_qualname = f"{_TE_OP_NAMESPACE}::{outer_bwd_name}"
 
-    _register_kernel(
+    inner_fwd_def = _register_kernel(
         op_name=inner_fwd_name,
-        op_qualname=inner_fwd_qualname,
+        schema_str=fwd_schema,
         arg_type=fwd_arg_type,
         arg_names=fwd_arg_names,
         buckets=fwd_buckets,
@@ -1231,7 +1228,7 @@ def _register_custom_op_impl(
     )
     _register_kernel(
         op_name=inner_bwd_name,
-        op_qualname=inner_bwd_qualname,
+        schema_str=bwd_schema,
         arg_type=backward_arg_type,
         arg_names=bwd_arg_names,
         buckets=bwd_buckets,
@@ -1239,6 +1236,17 @@ def _register_custom_op_impl(
         impl=backward_impl,
         fake_impl=bwd_fake_impl,
         format_result=lambda g: _format_bwd_result(g, num_grad_inputs, inner_bwd_qualname),
+    )
+
+    outer_fwd_def = _register_outer_forwarder(
+        outer_op_name=outer_fwd_name,
+        schema_str=fwd_schema,
+        inner_op_name=inner_fwd_name,
+        buckets=fwd_buckets,
+        subclass_list=list(subclass_list),
+    )
+    outer_bwd_def = _register_outer_forwarder(
+        outer_op_name=outer_bwd_name, schema_str=bwd_schema, inner_op_name=inner_bwd_name
     )
 
     autograd_common = {
@@ -1255,19 +1263,11 @@ def _register_custom_op_impl(
         "fwd_fake_impl": fwd_fake_impl,
     }
     _register_autograd_for_op(
-        fwd_op_name=inner_fwd_name, bwd_op_name=inner_bwd_name, **autograd_common
+        fwd_op=inner_fwd_def, bwd_op_name=inner_bwd_name, **autograd_common
     )
     _register_autograd_for_op(
-        fwd_op_name=outer_fwd_name, bwd_op_name=outer_bwd_name, **autograd_common
+        fwd_op=outer_fwd_def, bwd_op_name=outer_bwd_name, **autograd_common
     )
-
-    _register_outer_forwarder(
-        outer_op_name=outer_fwd_name,
-        inner_op_name=inner_fwd_name,
-        buckets=fwd_buckets,
-        subclass_list=list(subclass_list),
-    )
-    _register_outer_forwarder(outer_op_name=outer_bwd_name, inner_op_name=inner_bwd_name)
 
     inner_fwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), inner_fwd_name)
     inner_bwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), inner_bwd_name)
@@ -1292,8 +1292,8 @@ def _register_custom_op_impl(
         return inner_bwd_op(*new_args)
 
     for sub in subclass_list:
-        torch.library.register_torch_dispatch(outer_fwd_qualname, sub, _fwd_rule, lib=_TE_LIB)
-        torch.library.register_torch_dispatch(outer_bwd_qualname, sub, _bwd_rule, lib=_TE_LIB)
+        outer_fwd_def.register_torch_dispatch(sub, _fwd_rule)
+        outer_bwd_def.register_torch_dispatch(sub, _bwd_rule)
 
     _quantized_tensor_passthrough_ops.add(outer_fwd_op.default)
     _quantized_tensor_passthrough_ops.add(outer_bwd_op.default)

--- a/transformer_engine/pytorch/dynamo/custom_op.py
+++ b/transformer_engine/pytorch/dynamo/custom_op.py
@@ -40,6 +40,10 @@ _TE_OP_NAMESPACE = "transformer_engine_compile"
 # ``None`` entries in an op's flat ``Tensor[]`` return are smuggled through a
 # 0-element uint8 tensor: a non-nullable ``Tensor[]`` schema is required for
 # ``register_autograd`` to attach a ``grad_fn`` to the outputs.
+#
+# TODO: once https://github.com/pytorch/pytorch/pull/187434 lands, a nullable
+# ``Tensor?[]`` return schema lets ``None`` pass through directly and this
+# sentinel encoding (``_encode_none`` / ``_decode_none``) can be removed.
 _NONE_SENTINEL_DTYPE = torch.uint8
 
 

--- a/transformer_engine/pytorch/dynamo/custom_op.py
+++ b/transformer_engine/pytorch/dynamo/custom_op.py
@@ -1,0 +1,1322 @@
+# Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""torch.compile custom-op framework for Transformer Engine."""
+
+from __future__ import annotations
+import dataclasses
+import warnings
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+import torch
+
+from .tensor_proto import TensorProto, to_tensor_proto, _contiguous_stride
+from ..quantized_tensor import (
+    QuantizedTensor,
+    QuantizedTensorStorage,
+    Quantizer,
+    _STORAGE_REGISTRY,
+    _quantized_tensor_passthrough_ops,
+    prepare_for_saving,
+)
+
+_TE_OP_NAMESPACE = "transformer_engine_compile"
+_TE_LIB = torch.library.Library(_TE_OP_NAMESPACE, "FRAGMENT")  # noqa: TOR901
+
+
+# ``None`` entries in an op's flat ``Tensor[]`` return are smuggled through a
+# 0-element uint8 tensor: a non-nullable ``Tensor[]`` schema is required for
+# ``register_autograd`` to attach a ``grad_fn`` to the outputs.
+_NONE_SENTINEL_DTYPE = torch.uint8
+
+
+def _encode_none(t: Optional[torch.Tensor]) -> torch.Tensor:
+    """Replace ``None`` with a 0-element uint8 sentinel tensor."""
+    if t is None:
+        return torch.empty(0, dtype=_NONE_SENTINEL_DTYPE)
+    return t
+
+
+def _decode_none(t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    """Inverse of :func:`_encode_none`."""
+    if t is None:
+        return None
+    if t.numel() == 0 and t.dtype == _NONE_SENTINEL_DTYPE:
+        return None
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# OpaqueValueBundle: bundle of simple / value-opaque Python values
+# --------------------------------------------------------------------------- #
+
+
+class OpaqueValueBundle:
+    """Opaque value-type bundle of simple Python values.
+
+    Wraps a ``{name: value}`` dict so many small non-Tensor args pass through a
+    single custom-op input; registered as a torch.compile *value* opaque type
+    (Dynamo specializes the graph on its contents). Allowed values: primitives
+    in :attr:`PRIMITIVE_TYPES` (incl. ``torch.Size``), ``enum.Enum``, any
+    registered value-opaque type (e.g. TE quantizers), plus nested tuples /
+    lists / dicts thereof (so a bundle can carry a ``__tensor_flatten__``
+    context verbatim).
+    """
+
+    PRIMITIVE_TYPES: Tuple[type, ...] = (
+        type(None),
+        bool,
+        int,
+        float,
+        str,
+        torch.dtype,
+        torch.device,
+        torch.Size,
+    )
+
+    @classmethod
+    def is_simple_value(cls, value: Any) -> bool:
+        """Whether ``value`` may be stored inside an instance (recursive)."""
+        if isinstance(value, cls.PRIMITIVE_TYPES):
+            return True
+        if isinstance(value, Enum):
+            return True
+        if _is_opaque_value_type(type(value)):
+            return True
+        if isinstance(value, dict):
+            return all(
+                isinstance(k, str) and cls.is_simple_value(v) for k, v in value.items()
+            )
+        if isinstance(value, (list, tuple)):
+            return all(cls.is_simple_value(v) for v in value)
+        return False
+
+    @classmethod
+    def _to_hashable(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return tuple(sorted((k, cls._to_hashable(v)) for k, v in value.items()))
+        if isinstance(value, (list, tuple, torch.Size)):
+            return tuple(cls._to_hashable(v) for v in value)
+        return value
+
+    @classmethod
+    def _fmt_simple(cls, value: Any) -> str:
+        """Repr for a value, evaluable in a context with ``torch`` globals."""
+        if isinstance(value, torch.dtype):
+            return f"__import__('torch').{str(value).split('.')[-1]}"
+        if isinstance(value, torch.device):
+            return f"__import__('torch').device({str(value)!r})"
+        if isinstance(value, torch.Size):
+            return f"__import__('torch').Size({list(value)!r})"
+        # Enum before primitives: IntEnum is also ``int`` but must render as
+        # ``EnumName.MEMBER`` (the Enum class is added to globals by ``_collect``).
+        if isinstance(value, Enum):
+            return f"{type(value).__name__}.{value.name}"
+        if isinstance(value, dict):
+            body = ", ".join(f"{k!r}: {cls._fmt_simple(v)}" for k, v in value.items())
+            return f"{{{body}}}"
+        if isinstance(value, list):
+            return "[" + ", ".join(cls._fmt_simple(v) for v in value) + "]"
+        if isinstance(value, tuple):
+            body = ", ".join(cls._fmt_simple(v) for v in value)
+            return f"({body},)" if len(value) == 1 else f"({body})"
+        if _is_opaque_value_type(type(value)):
+            return value.__fx_repr__()[0]
+        return repr(value)
+
+    def __init__(self, data: Optional[Dict[str, Any]] = None) -> None:
+        data = dict(data) if data else {}
+        for k, v in data.items():
+            if not OpaqueValueBundle.is_simple_value(v):
+                raise TypeError(
+                    f"OpaqueValueBundle field '{k}' has unsupported type "
+                    f"{type(v).__name__}; only simple primitives, Enum, "
+                    "torch.Size, registered value-opaque types and nested "
+                    "tuples / lists / dicts thereof are allowed."
+                )
+        self._data: Dict[str, Any] = data
+        self._frozen: Tuple[Tuple[str, Any], ...] = tuple(
+            (k, OpaqueValueBundle._to_hashable(v)) for k, v in sorted(data.items())
+        )
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._data[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return ``self._data.get(key, default)``."""
+        return self._data.get(key, default)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return a shallow copy of the stored mapping."""
+        return dict(self._data)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, OpaqueValueBundle):
+            return NotImplemented
+        return self._frozen == other._frozen
+
+    def __hash__(self) -> int:
+        return hash(self._frozen)
+
+    def __fx_repr__(self) -> Tuple[str, Dict[str, Any]]:
+        items = ", ".join(
+            f"{k!r}: {OpaqueValueBundle._fmt_simple(v)}" for k, v in self._data.items()
+        )
+        globals_: Dict[str, Any] = {"OpaqueValueBundle": OpaqueValueBundle}
+
+        def _collect(value: Any) -> None:
+            if isinstance(value, dict):
+                for v in value.values():
+                    _collect(v)
+                return
+            if isinstance(value, (list, tuple)):
+                for v in value:
+                    _collect(v)
+                return
+            if isinstance(value, Enum):
+                globals_[type(value).__name__] = type(value)
+                return
+            if isinstance(value, OpaqueValueBundle.PRIMITIVE_TYPES):
+                return
+            if _is_opaque_value_type(type(value)):
+                _, extra = value.__fx_repr__()
+                globals_.update(extra)
+
+        for v in self._data.values():
+            _collect(v)
+        return (f"OpaqueValueBundle({{{items}}})", globals_)
+
+
+try:
+    from torch._library.opaque_object import (  # pylint: disable=import-outside-toplevel
+        get_opaque_type_name,
+        is_opaque_value_type as _is_opaque_value_type,
+        is_opaque_reference_type as _is_opaque_reference_type,
+        register_opaque_type,
+    )
+
+    register_opaque_type(OpaqueValueBundle, typ="value")
+    _OPAQUE_VALUE_BUNDLE_TYPE_NAME: Optional[str] = get_opaque_type_name(OpaqueValueBundle)
+except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover - older torch without opaque_object
+    _is_opaque_value_type = None
+    _is_opaque_reference_type = None
+    _OPAQUE_VALUE_BUNDLE_TYPE_NAME = None
+
+
+def _pg_pickle_stub(*args: Any) -> None:  # pragma: no cover
+    raise RuntimeError("ProcessGroup cannot be unpickled — cache-key use only")
+
+
+def _ensure_distributed_opaque_types() -> None:
+    """Register ``torch.distributed.ProcessGroup`` as a *reference* opaque type.
+
+    A process group is live distributed state: unlike a value-opaque quantizer
+    (which Dynamo bakes into the graph as a constant), it must be carried through
+    the custom op as a graph *input*. PyTorch supports this via
+    ``register_opaque_type(ProcessGroup, typ="reference")`` but only auto-runs it
+    when ``torch.distributed.tensor`` (DTensor) is imported; TE may not import
+    that, so trigger the same idempotent registration here. Best-effort: on
+    builds without the opaque-object / distributed APIs this is a no-op and the
+    process-group field simply falls back to eager under torch.compile.
+
+    Also registers a ``copyreg`` reducer that lets ``FxGraphCachePickler`` hash
+    graphs containing a ``ProcessGroup`` input without crashing.  Without this,
+    inductor logs "Failed to pickle cache key" warnings and bypasses the FX
+    graph disk cache for every distributed compiled call.  The reducer encodes
+    the group as (world_size, rank, backend) — enough to distinguish configs —
+    and raises on reconstruct since deserialization is never needed for hashing.
+    """
+    if _is_opaque_reference_type is None:
+        return
+    try:  # pylint: disable=import-outside-toplevel
+        from torch.distributed.device_mesh import _register_distributed_opaque_types
+
+        _register_distributed_opaque_types()
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    # Workaround for PyTorch issue: FxGraphCachePickler handles FakeScriptObject
+    # but not the real ProcessGroup that appears in example_inputs at inductor
+    # compile time.  Register a copyreg reducer so the pickler can hash the key.
+    try:  # pylint: disable=import-outside-toplevel
+        import copyreg
+        import torch.distributed as dist
+        from torch._C._distributed_c10d import ProcessGroup
+
+        if ProcessGroup not in copyreg.dispatch_table:
+
+            def _pg_reduce(pg: ProcessGroup) -> tuple:  # type: ignore[valid-type]
+                try:
+                    return _pg_pickle_stub, (
+                        dist.get_world_size(pg),
+                        dist.get_rank(pg),
+                        dist.get_backend(pg),
+                    )
+                except Exception:  # pylint: disable=broad-exception-caught
+                    return _pg_pickle_stub, (id(pg),)
+
+            copyreg.pickle(ProcessGroup, _pg_reduce)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+
+_ensure_distributed_opaque_types()
+
+
+# --------------------------------------------------------------------------- #
+# Storage flatten / unflatten (value-opaque quantizer; no ProcessGroup)
+# --------------------------------------------------------------------------- #
+
+
+def _storage_flatten(value: Any) -> Tuple["OpaqueValueBundle", List[torch.Tensor]]:
+    """Split a ``QuantizedTensor`` / bare storage into ``(meta, Tensor[])``.
+
+    The flatten context (embedding the value-opaque quantizer) plus inner names
+    and -- for a wrapper subclass -- the outer geometry are stashed in the bundle
+    so :func:`_storage_unflatten` can rebuild without PyTorch's ``outer_size``.
+    """
+    inner_names, ctx = value.__tensor_flatten__()
+    meta = dict(ctx)
+    meta["_inner_names"] = list(inner_names)
+    if isinstance(value, torch.Tensor):
+        meta["_outer_shape"] = torch.Size(value.shape)
+    tensors = [getattr(value, name) for name in inner_names]
+    return OpaqueValueBundle(meta), tensors
+
+
+def _storage_unflatten(meta: Any, tensors: List[torch.Tensor]) -> Any:
+    """Inverse of :func:`_storage_flatten`."""
+    meta_dict = meta.as_dict() if isinstance(meta, OpaqueValueBundle) else dict(meta)
+    inner_names = meta_dict["_inner_names"]
+    inner = dict(zip(inner_names, tensors))
+    outer_shape = meta_dict.get("_outer_shape")
+    stride = _contiguous_stride(tuple(outer_shape)) if outer_shape is not None else None
+    return QuantizedTensorStorage.__tensor_unflatten__(inner, meta_dict, outer_shape, stride)
+
+
+# --------------------------------------------------------------------------- #
+# Field buckets: dataclass field <-> flat torch.library slot(s)
+# --------------------------------------------------------------------------- #
+
+
+def _strip_optional(annot: Any) -> Tuple[Any, bool]:
+    """If ``annot`` is ``Optional[X]`` return ``(X, True)``; else ``(annot, False)``."""
+    if get_origin(annot) is Union:
+        args = get_args(annot)
+        if type(None) in args:
+            non_none = [a for a in args if a is not type(None)]
+            if len(non_none) == 1:
+                return non_none[0], True
+    return annot, False
+
+
+class _Bucket:
+    """Maps one (or, for the aggregating bucket, several) dataclass field(s)
+    to/from a contiguous run of custom-op schema *slots*.
+
+    A custom op only takes flat, simply-typed arguments, but a TE op takes a
+    single ``@dataclass`` of mixed fields. Each bucket knows how to translate
+    its kind of field both ways. ``try_build`` and ``schema_slots`` run once at
+    registration (to build the op's schema); ``pack`` and ``unpack`` run on each
+    call and must agree on the slot layout that ``schema_slots`` declares.
+    """
+
+    @classmethod
+    def try_build(cls, name: str, annot: Any) -> Optional["_Bucket"]:
+        """Decide whether this bucket type handles the field ``name`` given its
+        type annotation ``annot``; return a configured bucket if so, else
+        ``None`` so the next candidate is tried.
+
+        Called once per field at registration, in :data:`_FIELD_BUCKETS`
+        priority order.
+        """
+        raise NotImplementedError
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        """Declare the schema slots this field occupies, each as a
+        ``(slot_name, schema_type)`` pair (e.g. ``("bias", "Tensor?")``).
+
+        Concatenated across all buckets to form the op's schema string.
+        """
+        raise NotImplementedError
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        """Read this field from the dataclass ``owner`` and produce the concrete
+        value for each of its schema slots, as ``(slot_name, value)`` pairs.
+
+        Composite values are flattened to fit the (tensor-only) slots: e.g. a
+        quantized tensor is split into its plain inner buffers plus a metadata
+        bundle. Inverse of :meth:`unpack`.
+        """
+        raise NotImplementedError
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        """Read this field's slots back from the op arguments ``args`` and write
+        the reconstructed field value into ``kwargs`` (rebuilding any flattened
+        composite). The filled ``kwargs`` are then used to rebuild the original
+        dataclass for the eager implementation. Inverse of :meth:`pack`.
+        """
+        raise NotImplementedError
+
+    def grad_slot(self) -> Optional[int]:
+        """Index (within this bucket's :meth:`schema_slots`) of the slot that
+        carries a gradient, or ``None`` if the field is not differentiable.
+
+        Used to map ``input_tensors_for_grad`` names onto backward grad-output
+        positions. Non-tensor buckets (quantizers, metadata) return ``None``.
+        """
+        return None
+
+
+class _UniversalKind(Enum):
+    """What a universal-tensor slot group carries, tagged in its ``__meta``."""
+
+    NONE = "none"
+    TENSOR = "tensor"
+    STORAGE = "storage"
+
+
+class _UniversalTensorBucket(_Bucket):
+    """``Tensor | QuantizedTensorStorage`` (also subclass tensor) field.
+
+    Three slots regardless of value: ``<name>`` (``Tensor?`` -- plain / subclass
+    tensor passes through, ``None`` for bare storage), ``<name>__tensors``
+    (``Tensor[]`` flat inner tensors when flattened), ``<name>__meta``
+    (``OpaqueValueBundle`` flatten metadata + a ``__kind__`` marker).
+    """
+
+    KIND_KEY = "__kind__"
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def slot_name(self) -> str:
+        """Primary slot name for a plain / subclass tensor."""
+        return self.name
+
+    def slot_tensors(self) -> str:
+        """Flat inner-tensor slot name."""
+        return self.name + "__tensors"
+
+    def slot_meta(self) -> str:
+        """Flatten-metadata slot name."""
+        return self.name + "__meta"
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        return [
+            (self.slot_name(), "Tensor?"),
+            (self.slot_tensors(), "Tensor[]"),
+            (self.slot_meta(), _OPAQUE_VALUE_BUNDLE_TYPE_NAME),
+        ]
+
+    @staticmethod
+    def _is_tensor_storage_union(annot: Any) -> bool:
+        if get_origin(annot) is not Union:
+            return False
+        members = [a for a in get_args(annot) if a is not type(None)]
+        if torch.Tensor not in members:
+            return False
+        return any(
+            isinstance(m, type) and issubclass(m, QuantizedTensorStorage) for m in members
+        )
+
+    @classmethod
+    def try_build(cls, name: str, annot: Any) -> Optional["_UniversalTensorBucket"]:
+        if cls._is_tensor_storage_union(annot):
+            return cls(name)
+        return None
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        value = getattr(owner, self.name)
+        if value is None:
+            return [
+                (self.slot_name(), None),
+                (self.slot_tensors(), []),
+                (self.slot_meta(), OpaqueValueBundle({self.KIND_KEY: _UniversalKind.NONE})),
+            ]
+        if isinstance(value, torch.Tensor):
+            # Plain tensor *and* subclass (e.g. Float8Tensor) pass through the
+            # ``Tensor?`` slot; subclass flattening (if any) is done by the
+            # outer op's ``register_torch_dispatch`` rule.
+            return [
+                (self.slot_name(), value),
+                (self.slot_tensors(), []),
+                (self.slot_meta(), OpaqueValueBundle({self.KIND_KEY: _UniversalKind.TENSOR})),
+            ]
+        if isinstance(value, QuantizedTensorStorage):
+            meta, tensors = _storage_flatten(value)
+            meta._data[self.KIND_KEY] = _UniversalKind.STORAGE
+            return [
+                (self.slot_name(), None),
+                (self.slot_tensors(), list(tensors)),
+                (self.slot_meta(), meta),
+            ]
+        raise TypeError(
+            f"field {self.name!r} expected None, torch.Tensor, or "
+            f"QuantizedTensorStorage, got {type(value).__name__}"
+        )
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        meta = args[self.slot_meta()]
+        kind = meta.get(self.KIND_KEY)
+        if kind == _UniversalKind.NONE:
+            kwargs[self.name] = None
+        elif kind == _UniversalKind.TENSOR:
+            kwargs[self.name] = args[self.slot_name()]
+        else:
+            kwargs[self.name] = _storage_unflatten(meta, args[self.slot_tensors()])
+
+    def grad_slot(self) -> Optional[int]:
+        # Gradient flows to the plain / subclass tensor slot (``slot_name``,
+        # the first of the three).
+        return 0
+
+
+class _TensorBucket(_Bucket):
+    """``Tensor`` / ``Optional[Tensor]`` -> single ``Tensor`` / ``Tensor?`` slot."""
+
+    def __init__(self, name: str, is_optional: bool) -> None:
+        self.name = name
+        self.type_str = "Tensor?" if is_optional else "Tensor"
+
+    @classmethod
+    def try_build(cls, name: str, annot: Any) -> Optional["_TensorBucket"]:
+        stripped, is_optional = _strip_optional(annot)
+        if stripped is torch.Tensor:
+            return cls(name, is_optional)
+        return None
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        return [(self.name, self.type_str)]
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        return [(self.name, getattr(owner, self.name))]
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        kwargs[self.name] = args[self.name]
+
+    def grad_slot(self) -> Optional[int]:
+        return 0
+
+
+class _QuantizerBucket(_Bucket):
+    """``Quantizer`` / ``Optional[Quantizer]`` -> one own ``OpaqueValueBundle`` slot.
+
+    Each quantizer gets its own dedicated slot. The field is annotated with the
+    base ``Quantizer`` (not itself a registered opaque type), so the simple
+    bundle would not claim it.
+    """
+
+    KEY = "q"
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def slot(self) -> str:
+        """Opaque quantizer metadata slot name."""
+        return self.name + "__q"
+
+    @classmethod
+    def try_build(cls, name: str, annot: Any) -> Optional["_QuantizerBucket"]:
+        stripped, _ = _strip_optional(annot)
+        if not isinstance(stripped, type):
+            return None
+        if issubclass(stripped, Quantizer):
+            return cls(name)
+        return None
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        return [(self.slot(), _OPAQUE_VALUE_BUNDLE_TYPE_NAME)]
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        return [(self.slot(), OpaqueValueBundle({self.KEY: getattr(owner, self.name)}))]
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        kwargs[self.name] = args[self.slot()][self.KEY]
+
+
+class _ReferenceOpaqueBucket(_Bucket):
+    """``ProcessGroup`` (or any reference-opaque type) -> one own opaque slot.
+
+    A reference-opaque object is live, stateful black-box data (e.g. a
+    ``torch.distributed.ProcessGroup``): it cannot be specialized on or baked
+    into the graph as a constant the way a value-opaque quantizer is. torch.compile
+    instead carries it through as a graph *input*, so it passes straight through
+    its own schema slot (no ``OpaqueValueBundle`` wrapper). The field is annotated
+    with a concrete type registered via ``register_opaque_type(..., typ="reference")``.
+
+    On the fake / setup-context path the slot holds a ``FakeScriptObject`` (or
+    ``None``); it is assigned to the field verbatim, so the fake impl must never
+    read the object's contents.
+    """
+
+    def __init__(self, name: str, type_name: str, is_optional: bool) -> None:
+        self.name = name
+        self.type_str = f"{type_name}?" if is_optional else type_name
+
+    @classmethod
+    def try_build(cls, name: str, annot: Any) -> Optional["_ReferenceOpaqueBucket"]:
+        if _is_opaque_reference_type is None:
+            return None
+        stripped, is_optional = _strip_optional(annot)
+        if not isinstance(stripped, type):
+            return None
+        if _is_opaque_reference_type(stripped):
+            return cls(name, get_opaque_type_name(stripped), is_optional)
+        return None
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        return [(self.name, self.type_str)]
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        return [(self.name, getattr(owner, self.name))]
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        kwargs[self.name] = args[self.name]
+
+
+class _SimpleBundleBucket(_Bucket):
+    """Aggregates every simple-typed field into a single OpaqueValueBundle."""
+
+    SLOT = "_simple_meta"
+
+    def __init__(self, names: List[str]) -> None:
+        self.names = list(names)
+
+    @classmethod
+    def matches_field(cls, annot: Any) -> bool:
+        """Whether ``annot`` (Optional-aware, recursive) is bundle-simple."""
+        annot, _ = _strip_optional(annot)
+        if annot in OpaqueValueBundle.PRIMITIVE_TYPES:
+            return True
+        if isinstance(annot, type) and issubclass(annot, Enum):
+            return True
+        if (
+            isinstance(annot, type)
+            and _is_opaque_value_type is not None
+            and _is_opaque_value_type(annot)
+        ):
+            return True
+        if get_origin(annot) in (tuple, list):
+            inner = [a for a in get_args(annot) if a is not Ellipsis]
+            return bool(inner) and all(cls.matches_field(a) for a in inner)
+        return False
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        return [(self.SLOT, _OPAQUE_VALUE_BUNDLE_TYPE_NAME)]
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        return [(self.SLOT, OpaqueValueBundle({n: getattr(owner, n) for n in self.names}))]
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        if self.SLOT not in args:
+            return
+        meta = args[self.SLOT]
+        for n in self.names:
+            kwargs[n] = meta[n]
+
+
+class _UnknownBucket(_Bucket):
+    """Fallback for fields no other bucket claims.
+
+    Emits no slot; pack rejects non-trivial values (anything other than
+    ``None`` / all-``None`` sequence); unpack restores the field as ``None``.
+    """
+
+    def __init__(self, name: str, owner_cls_name: str) -> None:
+        self.name = name
+        self.owner_cls_name = owner_cls_name
+
+    @staticmethod
+    def _is_trivial(value: Any) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, (list, tuple)):
+            return all(v is None for v in value)
+        return False
+
+    def schema_slots(self) -> List[Tuple[str, str]]:
+        return []
+
+    def pack(self, owner: Any) -> List[Tuple[str, Any]]:
+        value = getattr(owner, self.name, None)
+        if not self._is_trivial(value):
+            raise TypeError(
+                f"{self.owner_cls_name} field {self.name!r} has a type not "
+                "supported by torch.compile (not Tensor, simple, or Quantizer) "
+                "and carries a non-trivial value; add a matching bucket in "
+                "dynamo.py to handle it."
+            )
+        return []
+
+    def unpack(self, args: Dict[str, Any], kwargs: Dict[str, Any]) -> None:
+        kwargs[self.name] = None
+
+
+# Buckets, in priority order, owning ``try_build`` for a single field.
+_FIELD_BUCKETS: Tuple[type, ...] = (
+    _UniversalTensorBucket,
+    _TensorBucket,
+    _ReferenceOpaqueBucket,
+    _QuantizerBucket,
+)
+
+
+def _resolved_field_annotations(cls: type) -> List[Tuple[str, Any]]:
+    """Return ``[(field_name, resolved_type), ...]`` for a dataclass."""
+    if not dataclasses.is_dataclass(cls):
+        raise TypeError(f"{cls.__name__} must be a @dataclass to be a TE op arg container.")
+    try:
+        hints = get_type_hints(cls)
+    except Exception:  # pylint: disable=broad-exception-caught
+        hints = {}
+    return [(f.name, hints.get(f.name, f.type)) for f in dataclasses.fields(cls)]
+
+
+def _get_buckets(cls: type) -> List[_Bucket]:
+    """Build the bucket list for a dataclass from its field annotations."""
+    if _OPAQUE_VALUE_BUNDLE_TYPE_NAME is None:
+        raise RuntimeError(
+            f"{cls.__name__} cannot be turned into a TE custom op: OpaqueValueBundle "
+            "is not registered as a torch._library value-opaque type (PyTorch build "
+            "without opaque-object support)."
+        )
+    buckets: List[_Bucket] = []
+    simple_names: List[str] = []
+    for name, annot in _resolved_field_annotations(cls):
+        built: Optional[_Bucket] = None
+        for bucket_cls in _FIELD_BUCKETS:
+            built = bucket_cls.try_build(name, annot)
+            if built is not None:
+                break
+        if built is not None:
+            buckets.append(built)
+        elif _SimpleBundleBucket.matches_field(annot):
+            simple_names.append(name)
+        else:
+            buckets.append(_UnknownBucket(name, cls.__name__))
+    if simple_names:
+        buckets.append(_SimpleBundleBucket(simple_names))
+    return buckets
+
+
+def _tensor_field_names(buckets: List[_Bucket]) -> List[str]:
+    """Names of fields carrying tensors (for building the proto view)."""
+    return [b.name for b in buckets if isinstance(b, (_TensorBucket, _UniversalTensorBucket))]
+
+
+def _build_schema(buckets: List[_Bucket]) -> Tuple[str, List[str]]:
+    """Return ``(schema_arg_str, slot_names)`` for a bucket list."""
+    spec = [slot for b in buckets for slot in b.schema_slots()]
+    names = [name for name, _ in spec]
+    schema_str = "(" + ", ".join(f"{type_str} {name}" for name, type_str in spec) + ")"
+    return schema_str, names
+
+
+def _pack(obj: Any, buckets: List[_Bucket]) -> Dict[str, Any]:
+    """Build the op's flat ``{slot_name: value}`` argument dict from an args
+    dataclass ``obj`` (e.g. ``LinearFwdArgs``), by collecting every bucket's
+    packed slot(s). Inverse of :func:`_unpack`.
+    """
+    out: Dict[str, Any] = {}
+    for bucket in buckets:
+        for name, value in bucket.pack(obj):
+            out[name] = value
+    return out
+
+
+def _unpack(cls: type, args: Dict[str, Any], buckets: List[_Bucket]) -> Any:
+    """Rebuild a fresh args dataclass ``cls`` (e.g. ``LinearFwdArgs``) from the
+    op's flat slot ``args`` dict, by letting every bucket restore its field(s).
+    Inverse of :func:`_pack`.
+    """
+    kwargs: Dict[str, Any] = {}
+    for bucket in buckets:
+        bucket.unpack(args, kwargs)
+    obj = cls.__new__(cls)
+    for k, v in kwargs.items():
+        object.__setattr__(obj, k, v)
+    return obj
+
+
+def _proto_view(obj: Any, tensor_field_names: Sequence[str]) -> Any:
+    """Copy of dataclass ``obj`` with each tensor field replaced by a :class:`TensorProto`.
+
+    Only tensor fields have a ``TensorProto`` equivalent, so quantizer / scalar
+    fields are simply carried over unchanged; the fake impl works purely on
+    geometry. Built with :func:`dataclasses.replace` (the only such construction
+    Dynamo can trace).
+    """
+    overrides: Dict[str, Any] = {}
+    for name in tensor_field_names:
+        value = getattr(obj, name, None)
+        if value is not None and not isinstance(value, TensorProto):
+            overrides[name] = to_tensor_proto(value)
+    if not overrides:
+        return obj
+    return dataclasses.replace(obj, **overrides)
+
+
+# --------------------------------------------------------------------------- #
+# Op outputs <-> flat ``Tensor[]`` payload: this is how an op returns / saves
+# quantized tensors (and wrapper subclasses). Outputs are flattened to their
+# inner buffers on the way out and rebuilt via ``__tensor_unflatten__`` on the
+# way back; on the fake side a TensorProto supplies the geometry.
+# --------------------------------------------------------------------------- #
+
+
+def _proto_slot_count(proto: Optional[TensorProto]) -> int:
+    """Flat ``Tensor[]`` slots the value for ``proto`` occupies."""
+    if proto is None:
+        return 1
+    return len(proto.inner_names())
+
+
+def _proto_reassemble(
+    proto: Optional[TensorProto],
+    chunk: List[Optional[torch.Tensor]],
+) -> Optional[Union[torch.Tensor, QuantizedTensorStorage]]:
+    """Rebuild the value described by ``proto`` from its flat tensors ``chunk``.
+
+    ``proto`` describes one output: ``None`` (-> ``None``), a plain tensor
+    (``chunk`` is the single tensor, returned as-is), or a quantized tensor
+    (``chunk`` are its inner tensors, reassembled into the wrapper subclass via
+    ``__tensor_unflatten__``).
+    """
+    if proto is None:
+        return None
+    if proto.quantizer is None:
+        return chunk[0]
+    inner_names = proto.inner_names()
+    meta = proto.create_metadata()
+    shape = tuple(proto.shape)
+    stride = _contiguous_stride(shape)
+    storage_cls = _STORAGE_REGISTRY[meta["cls"]]
+    inner_dict = dict(zip(inner_names, chunk))
+    return storage_cls.__tensor_unflatten__(inner_dict, meta, shape, stride)
+
+
+def _value_to_flat_tensors(
+    value: Optional[Union[torch.Tensor, QuantizedTensorStorage, TensorProto]],
+) -> List[torch.Tensor]:
+    """Return the flat ``Tensor[]`` slots that represent one op output ``value``.
+
+    Inverse of :func:`_proto_reassemble`; the slot count matches
+    :func:`_proto_slot_count`.
+    """
+    if value is None:
+        return [_encode_none(None)]
+    if isinstance(value, TensorProto):
+        return [_encode_none(t) for t in value.create_inner_tensors()]
+    if isinstance(value, torch.Tensor):
+        if type(value) is not torch.Tensor and hasattr(  # pylint: disable=unidiomatic-typecheck
+            value, "__tensor_flatten__"
+        ):
+            inner_names, _ = value.__tensor_flatten__()
+            return [_encode_none(getattr(value, n)) for n in inner_names]
+        return [_encode_none(value)]
+    if hasattr(value, "__tensor_flatten__"):
+        inner_names, _ = value.__tensor_flatten__()
+        return [_encode_none(getattr(value, n)) for n in inner_names]
+    raise TypeError(
+        f"unsupported value type {type(value).__name__}; expected None / "
+        "torch.Tensor / tensor subclass / bare storage / TensorProto."
+    )
+
+
+# Trailing slots in every fwd-impl return: ``tensors_to_save, tensor_objects,
+# ctx_attrs``. User-output count is ``len(result) - this``.
+_FWD_TRAILING_SLOTS = 3
+
+
+def _format_fwd_result(result: Any) -> List[torch.Tensor]:
+    """Pack a fwd-impl return tuple into the op's ``Tensor[]`` payload.
+
+    User outputs first, then saved-for-backward tensors in declaration order.
+    """
+    num_outputs = len(result) - _FWD_TRAILING_SLOTS
+    flat: List[torch.Tensor] = []
+    for value in result[:num_outputs]:
+        flat.extend(_value_to_flat_tensors(value))
+    saved = result[num_outputs] or ()
+    for value in saved:
+        flat.extend(_value_to_flat_tensors(value))
+    return flat
+
+
+def _format_bwd_result(grads: Any, num_grad_inputs: int, op_qualname: str) -> List[torch.Tensor]:
+    """Pack a backward-impl return tuple into the op's ``Tensor[]`` payload.
+
+    Each grad occupies exactly one slot (validated against ``num_grad_inputs``);
+    a :class:`TensorProto` grad is materialized into a single tensor.
+    """
+    grads = list(grads)
+    if len(grads) != num_grad_inputs:
+        raise RuntimeError(
+            f"{op_qualname} expected backward_impl to return {num_grad_inputs} grads "
+            f"(one per input_tensors_for_grad entry), got {len(grads)}"
+        )
+    out: List[torch.Tensor] = []
+    for g in grads:
+        if isinstance(g, TensorProto):
+            out.append(_encode_none(g.create_tensor()))
+        else:
+            out.append(_encode_none(g))
+    return out
+
+
+def _split_fwd_fake_result(
+    result: Tuple[Any, ...],
+) -> Tuple[List[Any], List[Any], Dict[str, Any]]:
+    """Slice a fwd fake-impl return into ``(user_fakes, saved_fakes, ctx_attrs)``."""
+    num_outputs = len(result) - _FWD_TRAILING_SLOTS
+    saved = result[num_outputs]
+    ctx_attrs = result[num_outputs + 2]
+    user_fakes = list(result[:num_outputs])
+    saved_fakes = list(saved) if saved is not None else []
+    ctx_attrs = dict(ctx_attrs) if ctx_attrs else {}
+    return user_fakes, saved_fakes, ctx_attrs
+
+
+# --------------------------------------------------------------------------- #
+# Op registration
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_grad_targets(
+    fwd_buckets: List[_Bucket],
+    fwd_arg_type: type,
+    input_tensors_for_grad: List[str],
+) -> Tuple[List[Any], List[int]]:
+    """Validate ``input_tensors_for_grad`` and resolve the grad-output layout.
+
+    Returns ``(fwd_slot_defaults, grad_targets)``: the per-slot no-grad template
+    (``[]`` for ``Tensor[]`` slots, ``None`` otherwise) and, for each requested
+    input name, the schema-slot index its gradient maps to.
+    """
+    fwd_slot_defaults: List[Any] = []
+    name_to_slot: Dict[str, int] = {}
+    slot_offset = 0
+    for bucket in fwd_buckets:
+        slots = bucket.schema_slots()
+        for _, type_str in slots:
+            fwd_slot_defaults.append([] if type_str.endswith("[]") else None)
+        grad_slot = bucket.grad_slot()
+        if grad_slot is not None:
+            name_to_slot[bucket.name] = slot_offset + grad_slot
+        slot_offset += len(slots)
+
+    unknown = [n for n in input_tensors_for_grad if n not in name_to_slot]
+    if unknown:
+        raise ValueError(
+            f"input_tensors_for_grad contains names not in {fwd_arg_type.__name__} "
+            f"schema: {unknown}"
+        )
+    grad_targets = [name_to_slot[n] for n in input_tensors_for_grad]
+    return fwd_slot_defaults, grad_targets
+
+
+def _register_kernel(
+    *,
+    op_name: str,
+    op_qualname: str,
+    arg_type: type,
+    arg_names: List[str],
+    buckets: List[_Bucket],
+    tensor_field_names: List[str],
+    impl: Callable[[Any], Any],
+    fake_impl: Callable[[Any], Any],
+    format_result: Callable[[Any], List[torch.Tensor]],
+) -> None:
+    """Wire the real ``impl`` + the ``fake_impl`` (proto) into the library.
+
+    The real kernel rebuilds the dataclass and runs ``impl``; the fake kernel
+    runs the proto fake impl on the :func:`_proto_view`. Both go through
+    ``format_result``.
+    """
+
+    def _impl(*flat: Any) -> List[torch.Tensor]:
+        kwargs = dict(zip(arg_names, flat))
+        obj = _unpack(arg_type, kwargs, buckets)
+        return format_result(impl(obj))
+
+    def _fake(*flat: Any) -> List[torch.Tensor]:
+        kwargs = dict(zip(arg_names, flat))
+        obj = _unpack(arg_type, kwargs, buckets)
+        proto_obj = _proto_view(obj, tensor_field_names)
+        return format_result(fake_impl(proto_obj))
+
+    _TE_LIB.impl(op_name, _impl, "CompositeExplicitAutograd")
+    torch.library.register_fake(op_qualname, _fake, lib=_TE_LIB)
+
+
+def _register_autograd_for_op(
+    *,
+    fwd_op_name: str,
+    bwd_op_name: str,
+    fwd_arg_type: type,
+    fwd_arg_names: List[str],
+    fwd_buckets: List[_Bucket],
+    fwd_tensor_field_names: List[str],
+    bwd_arg_names: List[str],
+    bwd_buckets: List[_Bucket],
+    fwd_slot_defaults: List[Any],
+    grad_targets: List[int],
+    setup_context_user: Callable[..., Any],
+    backward_obj_type: type,
+    fwd_fake_impl: Callable[[Any], Tuple[Any, ...]],
+) -> None:
+    """Wire ``register_autograd`` on a forward op so its backward calls ``bwd_op_name``.
+
+    ``setup_context`` re-runs the proto fwd fake impl to recover output / saved
+    templates, reassembles each flat output chunk, and hands the saved tuple +
+    ``ctx_attrs`` to the module's ``setup_context``.
+    """
+    fwd_qualname = f"{_TE_OP_NAMESPACE}::{fwd_op_name}"
+
+    def _setup_context(ctx, inputs, output):
+        ctx._te_fwd_tensor_list_lengths = {
+            i: len(value) for i, value in enumerate(inputs) if isinstance(value, list)
+        }
+        kwargs = dict(zip(fwd_arg_names, inputs))
+        fwd_obj = _unpack(fwd_arg_type, kwargs, fwd_buckets)
+        proto_obj = _proto_view(fwd_obj, fwd_tensor_field_names)
+
+        user_fakes, saved_fakes, ctx_attrs = _split_fwd_fake_result(fwd_fake_impl(proto_obj))
+
+        cursor = 0
+        user_outputs: List[Any] = []
+        for proto in user_fakes:
+            n = _proto_slot_count(proto)
+            chunk = [_decode_none(t) for t in output[cursor : cursor + n]]
+            cursor += n
+            user_outputs.append(_proto_reassemble(proto, chunk))
+
+        saved_list: List[Any] = []
+        for proto in saved_fakes:
+            n = _proto_slot_count(proto)
+            chunk = [_decode_none(t) for t in output[cursor : cursor + n]]
+            cursor += n
+            saved_list.append(_proto_reassemble(proto, chunk))
+
+        bwd_obj = backward_obj_type()
+        tensors_to_save_from_setup = setup_context_user(
+            bwd_obj,
+            fwd_obj,
+            user_outputs[0] if len(user_fakes) == 1 else tuple(user_outputs),
+            ctx_attrs,
+            tuple(saved_list),
+        )
+        tensors_to_save, tensor_objects = prepare_for_saving(
+            *(tensors_to_save_from_setup or ())
+        )
+        ctx.tensor_objects = tensor_objects
+        ctx.save_for_backward(*tensors_to_save)
+        ctx.bwd_obj = bwd_obj
+
+    def _autograd_backward(ctx, *grad_outputs):
+        bwd_obj = ctx.bwd_obj
+        if hasattr(bwd_obj, "setup_saved_tensors"):
+            bwd_obj.setup_saved_tensors(ctx)
+        ctx.tensor_objects = None
+        per_output_grads = grad_outputs[0]
+        bwd_obj.grad_output = _decode_none(per_output_grads[0])
+        kwargs = _pack(bwd_obj, bwd_buckets)
+        bwd_args_flat = [kwargs[name] for name in bwd_arg_names]
+        bwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), bwd_op_name)
+        grads = [_decode_none(g) for g in bwd_op(*bwd_args_flat)]
+        out: List[Any] = list(fwd_slot_defaults)
+        tensor_list_lengths = getattr(ctx, "_te_fwd_tensor_list_lengths", {})
+        for pos, length in tensor_list_lengths.items():
+            if isinstance(out[pos], list):
+                out[pos] = [None] * length
+        for pos, g in zip(grad_targets, grads):
+            out[pos] = g
+        return tuple(out)
+
+    torch.library.register_autograd(
+        fwd_qualname,
+        _autograd_backward,
+        setup_context=_setup_context,
+        lib=_TE_LIB,
+    )
+
+
+def _collect_universal_slot_offsets(buckets: List[_Bucket]) -> List[int]:
+    """Start index of each ``_UniversalTensorBucket`` group in the flat args."""
+    offsets: List[int] = []
+    pos = 0
+    for bucket in buckets:
+        if isinstance(bucket, _UniversalTensorBucket):
+            offsets.append(pos)
+        pos += len(bucket.schema_slots())
+    return offsets
+
+
+def _flatten_subclass_into_slots(
+    new_args: List[Any], slot_offsets: List[int], subclass: type
+) -> None:
+    """Rewrite each universal-bucket group whose ``Tensor?`` slot holds an
+    instance of ``subclass`` into the storage layout (3 slots: name / tensors / meta).
+    """
+    for offset in slot_offsets:
+        val = new_args[offset]
+        if val is None or not isinstance(val, subclass):
+            continue
+        meta, tensors = _storage_flatten(val)
+        meta._data[_UniversalTensorBucket.KIND_KEY] = _UniversalKind.STORAGE
+        new_args[offset] = None
+        new_args[offset + 1] = list(tensors)
+        new_args[offset + 2] = meta
+
+
+def _register_outer_forwarder(
+    *,
+    outer_op_name: str,
+    inner_op_name: str,
+    buckets: Optional[List[_Bucket]] = None,
+    subclass_list: Optional[List[type]] = None,
+) -> None:
+    """Register the outer op's default kernel + fake: forward to the inner op,
+    optionally flattening registered subclass inputs in place first.
+    """
+    inner_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), inner_op_name)
+    input_flatten_enabled = bool(subclass_list) and buckets is not None
+    slot_offsets = _collect_universal_slot_offsets(buckets) if input_flatten_enabled else []
+
+    def _forward(*flat: Any) -> List[torch.Tensor]:
+        if not input_flatten_enabled:
+            return inner_op(*flat)
+        new_args = list(flat)
+        for sub in subclass_list:
+            _flatten_subclass_into_slots(new_args, slot_offsets, sub)
+        return inner_op(*new_args)
+
+    _TE_LIB.impl(outer_op_name, _forward, "CompositeExplicitAutograd")
+    torch.library.register_fake(f"{_TE_OP_NAMESPACE}::{outer_op_name}", _forward, lib=_TE_LIB)
+
+
+def _all_quantized_tensor_subclasses() -> List[type]:
+    """Return every imported ``QuantizedTensor`` wrapper subclass."""
+    import transformer_engine.pytorch.tensor  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+    return [cls for cls in _STORAGE_REGISTRY.values() if issubclass(cls, QuantizedTensor)]
+
+
+def register_custom_op(
+    *,
+    op_name: str,
+    input_tensors_for_grad: List[str],
+    fwd_arg_type: type,
+    fwd_impl: Callable[[Any], Any],
+    setup_context: Callable[..., Any],
+    backward_arg_type: type,
+    backward_obj: type,
+    backward_impl: Callable[[Any], Any],
+    fwd_fake_impl: Callable[[Any], Tuple[Any, ...]],
+    bwd_fake_impl: Callable[[Any], Tuple[Any, ...]],
+) -> Optional[Callable[..., Any]]:
+    """Register a TE module's forward + backward as torch custom ops.
+
+    Always two-tier: an inner ``<op>_base`` op carries the real schema /
+    autograd, and an outer ``<op>`` op forwards to it, flattening any
+    quantized-tensor wrapper inputs first via ``register_torch_dispatch`` (an
+    empty subclass list simply makes the outer op a pass-through, so a pure
+    plain-tensor / bf16 call goes straight through).
+
+    Returns ``forward_fn(fwd_arg_type_instance)`` -- a drop-in for
+    ``Function.apply`` under ``torch.compiler.is_compiling()`` that dispatches
+    through the outer op and returns the user-facing outputs.
+
+    Registration touches experimental ``torch.library`` / opaque-object APIs
+    that may be missing on older PyTorch. If it fails, this warns once and
+    returns ``None`` instead of raising, so callers can fall back to eager under
+    ``torch.compile`` (a graph break) rather than breaking import.
+    """
+    try:
+        return _register_custom_op_impl(
+            op_name=op_name,
+            input_tensors_for_grad=input_tensors_for_grad,
+            fwd_arg_type=fwd_arg_type,
+            fwd_impl=fwd_impl,
+            setup_context=setup_context,
+            backward_arg_type=backward_arg_type,
+            backward_obj=backward_obj,
+            backward_impl=backward_impl,
+            fwd_fake_impl=fwd_fake_impl,
+            bwd_fake_impl=bwd_fake_impl,
+        )
+    except (ImportError, AttributeError, RuntimeError, TypeError) as e:
+        warnings.warn(
+            f"Could not register the torch.compile custom op '{op_name}' "
+            f"({type(e).__name__}: {e}); modules using it will fall back to eager "
+            "execution under torch.compile (a graph break, incompatible with "
+            "fullgraph=True)."
+        )
+        return None
+
+
+def _register_custom_op_impl(
+    *,
+    op_name: str,
+    input_tensors_for_grad: List[str],
+    fwd_arg_type: type,
+    fwd_impl: Callable[[Any], Any],
+    setup_context: Callable[..., Any],
+    backward_arg_type: type,
+    backward_obj: type,
+    backward_impl: Callable[[Any], Any],
+    fwd_fake_impl: Callable[[Any], Tuple[Any, ...]],
+    bwd_fake_impl: Callable[[Any], Tuple[Any, ...]],
+) -> Callable[..., Any]:
+    """Body of :func:`register_custom_op`; see it for semantics."""
+    outer_fwd_name = op_name
+    outer_bwd_name = f"{op_name}_backward"
+    inner_fwd_name = f"{op_name}_base"
+    inner_bwd_name = f"{outer_bwd_name}_base"
+    subclass_list = _all_quantized_tensor_subclasses()
+
+    fwd_buckets = _get_buckets(fwd_arg_type)
+    bwd_buckets = _get_buckets(backward_arg_type)
+    fwd_tensor_field_names = _tensor_field_names(fwd_buckets)
+    bwd_tensor_field_names = _tensor_field_names(bwd_buckets)
+
+    fwd_schema_args, fwd_arg_names = _build_schema(fwd_buckets)
+    bwd_schema_args, bwd_arg_names = _build_schema(bwd_buckets)
+
+    num_grad_inputs = len(input_tensors_for_grad)
+    fwd_slot_defaults, grad_targets = _resolve_grad_targets(
+        fwd_buckets, fwd_arg_type, input_tensors_for_grad
+    )
+
+    _TE_LIB.define(f"{inner_fwd_name}{fwd_schema_args} -> Tensor[]")
+    _TE_LIB.define(f"{inner_bwd_name}{bwd_schema_args} -> Tensor[]")
+    _TE_LIB.define(f"{outer_fwd_name}{fwd_schema_args} -> Tensor[]")
+    _TE_LIB.define(f"{outer_bwd_name}{bwd_schema_args} -> Tensor[]")
+
+    inner_fwd_qualname = f"{_TE_OP_NAMESPACE}::{inner_fwd_name}"
+    inner_bwd_qualname = f"{_TE_OP_NAMESPACE}::{inner_bwd_name}"
+    outer_fwd_qualname = f"{_TE_OP_NAMESPACE}::{outer_fwd_name}"
+    outer_bwd_qualname = f"{_TE_OP_NAMESPACE}::{outer_bwd_name}"
+
+    _register_kernel(
+        op_name=inner_fwd_name,
+        op_qualname=inner_fwd_qualname,
+        arg_type=fwd_arg_type,
+        arg_names=fwd_arg_names,
+        buckets=fwd_buckets,
+        tensor_field_names=fwd_tensor_field_names,
+        impl=fwd_impl,
+        fake_impl=fwd_fake_impl,
+        format_result=_format_fwd_result,
+    )
+    _register_kernel(
+        op_name=inner_bwd_name,
+        op_qualname=inner_bwd_qualname,
+        arg_type=backward_arg_type,
+        arg_names=bwd_arg_names,
+        buckets=bwd_buckets,
+        tensor_field_names=bwd_tensor_field_names,
+        impl=backward_impl,
+        fake_impl=bwd_fake_impl,
+        format_result=lambda g: _format_bwd_result(g, num_grad_inputs, inner_bwd_qualname),
+    )
+
+    autograd_common = {
+        "fwd_arg_type": fwd_arg_type,
+        "fwd_arg_names": fwd_arg_names,
+        "fwd_buckets": fwd_buckets,
+        "fwd_tensor_field_names": fwd_tensor_field_names,
+        "bwd_arg_names": bwd_arg_names,
+        "bwd_buckets": bwd_buckets,
+        "fwd_slot_defaults": fwd_slot_defaults,
+        "grad_targets": grad_targets,
+        "setup_context_user": setup_context,
+        "backward_obj_type": backward_obj,
+        "fwd_fake_impl": fwd_fake_impl,
+    }
+    _register_autograd_for_op(
+        fwd_op_name=inner_fwd_name, bwd_op_name=inner_bwd_name, **autograd_common
+    )
+    _register_autograd_for_op(
+        fwd_op_name=outer_fwd_name, bwd_op_name=outer_bwd_name, **autograd_common
+    )
+
+    _register_outer_forwarder(
+        outer_op_name=outer_fwd_name,
+        inner_op_name=inner_fwd_name,
+        buckets=fwd_buckets,
+        subclass_list=list(subclass_list),
+    )
+    _register_outer_forwarder(outer_op_name=outer_bwd_name, inner_op_name=inner_bwd_name)
+
+    inner_fwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), inner_fwd_name)
+    inner_bwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), inner_bwd_name)
+    outer_fwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), outer_fwd_name)
+    outer_bwd_op = getattr(getattr(torch.ops, _TE_OP_NAMESPACE), outer_bwd_name)
+
+    fwd_slot_offsets = _collect_universal_slot_offsets(fwd_buckets)
+    bwd_slot_offsets = _collect_universal_slot_offsets(bwd_buckets)
+
+    def _fwd_rule(mode, func, types, args, kwargs):
+        del mode, func, types, kwargs
+        new_args = list(args)
+        for sub in subclass_list:
+            _flatten_subclass_into_slots(new_args, fwd_slot_offsets, sub)
+        return inner_fwd_op(*new_args)
+
+    def _bwd_rule(mode, func, types, args, kwargs):
+        del mode, func, types, kwargs
+        new_args = list(args)
+        for sub in subclass_list:
+            _flatten_subclass_into_slots(new_args, bwd_slot_offsets, sub)
+        return inner_bwd_op(*new_args)
+
+    for sub in subclass_list:
+        torch.library.register_torch_dispatch(outer_fwd_qualname, sub, _fwd_rule, lib=_TE_LIB)
+        torch.library.register_torch_dispatch(outer_bwd_qualname, sub, _bwd_rule, lib=_TE_LIB)
+
+    _quantized_tensor_passthrough_ops.add(outer_fwd_op.default)
+    _quantized_tensor_passthrough_ops.add(outer_bwd_op.default)
+    _quantized_tensor_passthrough_ops.add(inner_fwd_op.default)
+    _quantized_tensor_passthrough_ops.add(inner_bwd_op.default)
+
+    def forward_fn(fwd_args):
+        proto_obj = _proto_view(fwd_args, fwd_tensor_field_names)
+        user_fakes, _saved_fakes, _ctx_attrs = _split_fwd_fake_result(fwd_fake_impl(proto_obj))
+        kwargs = _pack(fwd_args, fwd_buckets)
+        flat_in = [kwargs[name] for name in fwd_arg_names]
+        result = outer_fwd_op(*flat_in)
+
+        cursor = 0
+        outputs: List[Any] = []
+        for proto in user_fakes:
+            n = _proto_slot_count(proto)
+            chunk = [_decode_none(t) for t in result[cursor : cursor + n]]
+            cursor += n
+            outputs.append(_proto_reassemble(proto, chunk))
+
+        if len(outputs) == 1:
+            return outputs[0]
+        return tuple(outputs)
+
+    return forward_fn

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -424,11 +424,7 @@ class _LayerNormLinear(torch.autograd.Function):
         if ub_overlap_rs_fprop:
             # cuBLASMp writes the reduce-scattered output directly into the
             # GEMM output tensor; Userbuffers writes it into the extra-output buffer.
-            out = (
-                gemm_out
-                if ub_obj is not None and ub_obj.with_cublasmp()
-                else reduce_scatter_out
-            )
+            out = gemm_out if ub_obj is not None and ub_obj.with_cublasmp() else reduce_scatter_out
         elif parallel_mode == "row" and tp_size > 1:
             nvtx_range_push(f"{nvtx_label}.row_parallel_comm")
             out = gemm_out

--- a/transformer_engine/pytorch/module/layernorm_linear.py
+++ b/transformer_engine/pytorch/module/layernorm_linear.py
@@ -424,7 +424,11 @@ class _LayerNormLinear(torch.autograd.Function):
         if ub_overlap_rs_fprop:
             # cuBLASMp writes the reduce-scattered output directly into the
             # GEMM output tensor; Userbuffers writes it into the extra-output buffer.
-            out = gemm_out if ub_obj is not None and ub_obj.with_cublasmp() else reduce_scatter_out
+            out = (
+                gemm_out
+                if ub_obj is not None and ub_obj.with_cublasmp()
+                else reduce_scatter_out
+            )
         elif parallel_mode == "row" and tp_size > 1:
             nvtx_range_push(f"{nvtx_label}.row_parallel_comm")
             out = gemm_out

--- a/transformer_engine/pytorch/module/linear.py
+++ b/transformer_engine/pytorch/module/linear.py
@@ -3,10 +3,12 @@
 # See LICENSE for license information.
 
 """Linear API"""
+
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple, Union, List
 from functools import reduce
 from operator import mul as multiply_op
+import math
 import warnings
 import weakref
 
@@ -38,10 +40,10 @@ from ..utils import (
     divide,
     init_method_constant,
     needs_quantized_gemm,
-    assert_dim_for_fp8_exec,
     nvtx_range_pop,
     nvtx_range_push,
     get_nvtx_range_context,
+    warn_compile_eager_fallback,
 )
 from ..distributed import (
     set_tensor_model_parallel_attributes,
@@ -58,9 +60,10 @@ from ..distributed import (
 from ..cpp_extensions import (
     general_gemm,
 )
+from ..cpp_extensions.gemm import get_cublas_workspace
 from ..constants import FP8BwdTensorIdx, FP8FwdTensorIdx, GemmParallelModes, dist_group_type
-from ..jit import no_torch_dynamo
 from ..graph import is_graph_capturing
+from ..jit import no_torch_dynamo
 from ..quantized_tensor import (
     QuantizedTensor,
     QuantizedTensorStorage,
@@ -68,7 +71,7 @@ from ..quantized_tensor import (
     prepare_for_saving,
     restore_from_func_ctx,
 )
-from ..dynamo import TensorProto
+from ..dynamo import TensorProto, register_custom_op, is_value_opaque_quantizer
 from ..tensor.float8_tensor import Float8CurrentScalingQuantizer, Float8Quantizer
 from ..tensor.mxfp8_tensor import MXFP8Quantizer
 from ..tensor.utils import clear_columnwise_cache, is_custom
@@ -97,7 +100,24 @@ class LinearFwdArgs:
     bias: Optional[torch.Tensor]
 
     # --- Non-differentiable cached tensors ---
-    weight_workspace: Optional[torch.Tensor]
+    # Same union as ``weight`` so a cached quantized workspace is flattened to its
+    # inner tensors on the way into the op (symmetric with ``new_weight_workspace``
+    # on the way out); a plain ``Tensor?`` slot can't carry a quantized subclass
+    # across the torch.compile custom-op boundary.
+    weight_workspace: Optional[TensorOrQuantized]
+
+    # --- CUDA-graph workspace pinning (torch.compile / reduce-overhead) ---
+    # Fetched in the *traced* module forward and threaded in as op inputs purely so
+    # the process-global, lru_cached cuBLAS / NVFP4-RHT workspaces become graph
+    # inputs: they are then allocated at trace time in the normal allocator (external
+    # to the cudagraph private pool) instead of being created inside the op during
+    # capture, where a persistent allocation trips check_memory_pool ("tensor not
+    # tracked as outputs"). The op body never reads these; general_gemm / the
+    # quantizer fetch the same lru_cached globals by address. Pinning the workspace
+    # in the forward also covers the backward GEMM, which reuses the same cached
+    # global. None on eager / non-compiled paths.
+    cublas_workspace: Optional[torch.Tensor]
+    rht_matrix: Optional[torch.Tensor]
 
     # --- requires_grad flags (cached so backward does not re-query) ---
     input_requires_grad: bool
@@ -131,7 +151,9 @@ class LinearFwdArgs:
 
     # --- Tensor / sequence parallelism ---
     parallel_mode: Optional[str]
-    tp_group: Optional[Any]
+    # ProcessGroup is a *reference*-opaque type: carried through the torch.compile
+    # custom op as a graph input (never baked into the graph as a constant).
+    tp_group: Optional[dist_group_type]
     tp_size: int
     tensor_parallel: bool
     sequence_parallel: bool
@@ -158,6 +180,39 @@ class LinearFwdArgs:
     # --- Misc ---
     cpu_offloading: bool
     is_grad_enabled: bool
+
+    def compile_unsupported_reason(self) -> Optional[str]:
+        """Reason this config can't use the torch.compile custom-op path (else None)."""
+        if self.debug:
+            return "debug instrumentation (nvidia-dlfw-inspect)"
+        if self.fsdp_group is not None and self.is_grad_enabled:
+            return "manual TE FSDP (fsdp_group); use FSDP2 or MCore FSDP"
+        if (
+            self.fp8_output
+            and self.is_grad_enabled
+            and (self.input_requires_grad or self.weight_requires_grad)
+        ):
+            return "differentiable fp8_output=True"
+        if self.cpu_offloading:
+            return "CPU activation offloading"
+        if self.wgrad_store is not None:
+            # Non-None only when delayed wgrad compute is on (see Linear.forward).
+            return "delayed wgrad compute (wgrad_store)"
+        if self.fuse_wgrad_accumulation:
+            return "fuse_wgrad_accumulation (main_grad)"
+        for quantizer in (
+            self.input_quantizer,
+            self.weight_quantizer,
+            self.output_quantizer,
+            self.grad_input_quantizer,
+            self.grad_weight_quantizer,
+            self.grad_output_quantizer,
+        ):
+            # e.g. delayed-scaling Float8Quantizer and unregistered custom-recipe
+            # quantizers are not value-opaque and can't cross the custom-op boundary.
+            if quantizer is not None and not is_value_opaque_quantizer(quantizer):
+                return "a quantizer not registered as a torch.compile value-opaque type"
+        return None
 
 
 @dataclass(slots=True)
@@ -196,7 +251,8 @@ class LinearBwdArgs:
 
     # --- Tensor / sequence parallelism ---
     parallel_mode: Optional[str] = None
-    tp_group: Optional[Any] = None
+    # Reference-opaque ProcessGroup (graph input), see LinearFwdArgs.tp_group.
+    tp_group: Optional[dist_group_type] = None
     tp_size: int = 1
     tensor_parallel: bool = False
     sequence_parallel: bool = False
@@ -296,9 +352,7 @@ def _linear_forward_impl(
     if ub_name is not None:
         nvtx_label = f"{nvtx_label}.{ub_name}"
 
-    # Make sure input dimensions are compatible
-    out_features, in_features = weight.shape
-    assert inp.shape[-1] == in_features, "GEMM not possible"
+    out_features = weight.shape[0]
 
     # Configure tensor-parallel communication
     tp_world_size = get_distributed_world_size(tp_group)
@@ -340,7 +394,6 @@ def _linear_forward_impl(
     inputmat_total = None  # Input tensor to pass to GEMM (gathered)
     own_quantized_input = False
     if fp8:
-        assert_dim_for_fp8_exec(inputmat, weight)
         if save_original_input:
             assert not isinstance(
                 input_quantizer, Float8Quantizer
@@ -887,7 +940,10 @@ def _linear_setup_ctx(
     bwd_args.use_bias = bias is not None
     bwd_args.requires_dgrad = fwd_args.input_requires_grad
     bwd_args.requires_wgrad = fwd_args.weight_requires_grad
-    bwd_args.inp_shape = inp.shape
+    # Don't store inp_shape in the value bundle: under torch.compile(dynamic=True)
+    # inp.shape contains SymInt dims which are not hashable in OpaqueValueBundle.
+    # The backward reconstructs inp_shape from grad_output + weight + SP config.
+    bwd_args.inp_shape = None
 
     # Numerical / dtype config
     bwd_args.activation_dtype = fwd_args.activation_dtype
@@ -1034,6 +1090,19 @@ def _linear_backward(args: LinearBwdArgs) -> Tuple[Union[torch.Tensor, None], ..
             weight_fp8,
         )
         nvtx_range_pop(f"{nvtx_label}.fsdp_gather")
+
+        # Reconstruct inp_shape when not stored (compiled mode with dynamic shapes).
+        if bwd_args.inp_shape is None:
+            _w = saved_weight if saved_weight is not None else weight_fp8
+            in_features = _w.shape[-1]
+            go_leading = grad_output.shape[0]
+            if bwd_args.parallel_mode == "column" and bwd_args.sequence_parallel:
+                inp_leading = go_leading // bwd_args.tp_size
+            elif bwd_args.parallel_mode == "row" and bwd_args.sequence_parallel:
+                inp_leading = go_leading * bwd_args.tp_size
+            else:
+                inp_leading = go_leading
+            bwd_args.inp_shape = torch.Size([inp_leading, *grad_output.shape[1:-1], in_features])
 
         # Configure Userbuffers communication (comm+GEMM overlap)
         bwd_args.ub_obj_gradout = None
@@ -1574,8 +1643,19 @@ def _linear_backward_impl_fake(
     dgrad = None
     if args.requires_dgrad:
         # dgrad has the logical input shape and may be quantized for the next op.
+        # Derive shape from grad_output + weight + SP config instead of args.inp_shape:
+        # inp_shape is not stored in the value bundle under dynamic shapes (SymInt is
+        # not hashable in OpaqueValueBundle), so we reconstruct it here.
+        _in_features = weight.shape[-1]
+        _go_leading = args.grad_output.shape[0]
+        if args.parallel_mode == "column" and args.sequence_parallel:
+            _dgrad_leading = _go_leading // args.tp_size
+        elif args.parallel_mode == "row" and args.sequence_parallel:
+            _dgrad_leading = _go_leading * args.tp_size
+        else:
+            _dgrad_leading = _go_leading
         dgrad = TensorProto(
-            shape=tuple(args.inp_shape),
+            shape=(_dgrad_leading, *args.grad_output.shape[1:-1], _in_features),
             dtype=out_dtype,
             quantizer=args.grad_input_quantizer,
             device=args.grad_output.device,
@@ -1601,6 +1681,21 @@ def _linear_backward_impl_fake(
         )
 
     return wgrad, dgrad, grad_bias
+
+
+# Custom op used under ``torch.compile``.
+_linear_op = register_custom_op(
+    op_name="linear",
+    input_tensors_for_grad=["weight", "inp", "bias"],
+    fwd_arg_type=LinearFwdArgs,
+    fwd_impl=_linear_forward_impl,
+    fwd_fake_impl=_linear_forward_impl_fake,
+    setup_context=_linear_setup_ctx,
+    backward_arg_type=LinearBwdArgs,
+    backward_obj=LinearBwdArgs,
+    backward_impl=_linear_backward,
+    bwd_fake_impl=_linear_backward_impl_fake,
+)
 
 
 class _Linear(torch.autograd.Function):
@@ -1685,6 +1780,20 @@ class _Linear(torch.autograd.Function):
             FP8GlobalStateManager.reduce_and_update_fp8_tensors(forward=False)
             nvtx_range_pop(f"{nvtx_label}.reduce_and_update_fp8_tensors")
         return result
+
+
+@no_torch_dynamo()
+def _linear_eager(
+    weight_tensor: torch.Tensor,
+    inp: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    fwd_args: LinearFwdArgs,
+    is_grad_enabled: bool,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run ``_Linear`` eagerly, bypassing Dynamo."""
+    if is_grad_enabled:
+        return _Linear.apply(weight_tensor, inp, bias, fwd_args)
+    return _Linear.forward(None, weight_tensor, inp, bias, fwd_args)
 
 
 class Linear(TransformerEngineBaseModule):
@@ -2084,7 +2193,6 @@ class Linear(TransformerEngineBaseModule):
                     elif self.parallel_mode == "column":
                         set_tensor_model_parallel_attributes(getattr(self, bias), True, 0, 1)
 
-    @no_torch_dynamo()
     def forward(
         self,
         inp: torch.Tensor,
@@ -2159,12 +2267,7 @@ class Linear(TransformerEngineBaseModule):
                 grad_output_quantizer,
             ) = quantizers
 
-            if is_grad_enabled:
-                linear_fn = _Linear.apply
-                autograd_ctx = []
-            else:
-                linear_fn = _Linear.forward
-                autograd_ctx = [None]
+            use_compiled_op = torch.compiler.is_compiling() and _linear_op is not None
 
             cache_name = None if (is_first_microbatch is None or self.is_fsdp2) else "weight"
             weight_workspace = (
@@ -2204,16 +2307,58 @@ class Linear(TransformerEngineBaseModule):
                 ub_bulk_dgrad = self.ub_bulk_dgrad
                 ub_bulk_wgrad = self.ub_bulk_wgrad
 
+            torch._check(
+                inp.shape[-1] == weight_tensor.shape[-1],
+                lambda: "GEMM not possible: input last dim must equal in_features",
+            )
+            if self.fp8:
+                torch._check(
+                    math.prod(inp.shape[:-1]) % 8 == 0,
+                    lambda: (
+                        "FP8 execution requires the product of all input dimensions except"
+                        " the last to be divisible by 8"
+                    ),
+                )
+                torch._check(
+                    inp.shape[-1] % 16 == 0,
+                    lambda: "FP8 execution requires the input last dimension to be divisible by 16",
+                )
+                torch._check(
+                    weight_tensor.shape[0] % 16 == 0,
+                    lambda: "FP8 execution requires out_features to be divisible by 16",
+                )
+                torch._check(
+                    weight_tensor.shape[1] % 16 == 0,
+                    lambda: "FP8 execution requires in_features to be divisible by 16",
+                )
+
             linear_bias_tensor = (
                 bias_tensor if (self.apply_bias and not self.gemm_bias_unfused_add) else None
             )
             wgrad_store = self.wgrad_store if self.wgrad_store.delay_wgrad_compute() else None
+
+            # Pin the lazily-cached cuBLAS (and NVFP4-RHT) workspaces as op inputs so
+            # they are materialized at trace time (external to the cudagraph pool)
+            # rather than inside the op during capture. See LinearFwdArgs for details.
+            cublas_workspace = None
+            rht_matrix = None
+            if use_compiled_op:
+                cublas_workspace = get_cublas_workspace(inp.device.index, False, False)
+                from ..tensor.nvfp4_tensor import NVFP4Quantizer, get_rht_matrix
+
+                if isinstance(input_quantizer, NVFP4Quantizer):
+                    rht_matrix = get_rht_matrix(
+                        input_quantizer._with_random_sign_mask, inp.device.index
+                    )
+
             fwd_args = LinearFwdArgs(
                 # tensors
                 weight=weight_tensor,
                 inp=inp,
                 bias=linear_bias_tensor,
                 weight_workspace=weight_workspace,
+                cublas_workspace=cublas_workspace,
+                rht_matrix=rht_matrix,
                 # requires_grad flags
                 input_requires_grad=inp.requires_grad,
                 weight_requires_grad=weight_tensor.requires_grad,
@@ -2268,13 +2413,19 @@ class Linear(TransformerEngineBaseModule):
                 cpu_offloading=is_cpu_offload_enabled(),
                 is_grad_enabled=is_grad_enabled,
             )
-            out, new_weight_workspace = linear_fn(
-                *autograd_ctx,
-                weight_tensor,
-                inp,
-                linear_bias_tensor,
-                fwd_args,
-            )
+
+            if use_compiled_op:
+                fallback_reason = fwd_args.compile_unsupported_reason()
+                if fallback_reason is not None:
+                    warn_compile_eager_fallback(fallback_reason)
+                    use_compiled_op = False
+
+            if use_compiled_op:
+                out, new_weight_workspace = _linear_op(fwd_args)
+            else:
+                out, new_weight_workspace = _linear_eager(
+                    weight_tensor, inp, linear_bias_tensor, fwd_args, is_grad_enabled
+                )
 
             if new_weight_workspace is not None and cache_name is not None:
                 if isinstance(new_weight_workspace, torch.Tensor):

--- a/transformer_engine/pytorch/utils.py
+++ b/transformer_engine/pytorch/utils.py
@@ -26,6 +26,20 @@ __all__ = [
 ]
 
 
+def warn_compile_eager_fallback(reason: str) -> None:
+    """Warn that a TE module is running eagerly under ``torch.compile``.
+
+    Emitted when ``reason`` is unsupported on the module's compiled custom-op
+    path. Python's default warning filter dedups identical messages, so each
+    distinct ``reason`` is surfaced once.
+    """
+    warnings.warn(
+        f"Falling back to eager execution under torch.compile: {reason} is "
+        "unsupported on the compiled path (graph-breaks under fullgraph=True).",
+        stacklevel=2,
+    )
+
+
 @functools.lru_cache(maxsize=None)
 def get_cached_ones_tensor(
     num_elements: int,


### PR DESCRIPTION
Build a torch.compile custom-op framework in dynamo.py that traces Linear forward+backward as single graph nodes (no graph break into the eager autograd.Function):

- OpaqueSimpleMetadata bundle (with nested-dict support) and per-field buckets mapping the LinearFwd/BwdArgs dataclasses to op schema slots; quantizers ride through as value-opaque objects (own slot each).
- Fakes stay TensorProto -> TensorProto; the framework converts tensor inputs to TensorProto at the boundary (via dataclasses.replace, which Dynamo can trace) and materializes output protos into fake tensors in register_fake. Saved-tensor aliases resolved by name from ctx_attrs.
- Two-tier op + register_torch_dispatch flattens Float8Tensor weight inputs; quantized outputs are rebuilt via _ToSubclassFn (autograd-aware).
- Mirror _linear_forward_impl set_usage / input+weight pipeline in the forward fake so register_fake layout matches eager.
- Replace LinearBwdArgs.fp8_recipe with precomputed split-accumulator bools (recipe object is not compile-safe across the op boundary).
- Dispatch through the op under torch.compiler.is_compiling(); drop @no_torch_dynamo from Linear.forward.

Tests: test_te_linear_compiles (bf16 + every recipe), quantized FP8 weight input. Backward through a Float8Tensor output is a strict xfail (AOTAutograd demands a subclass cotangent and the linear backward has no FP8-cotangent path).

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
