### PR TITLE
Carry amax reduction group on QuantizedTensor; apply it in quantize _…

### DIFF
--- a/transformer_engine/pytorch/tensor/float8_tensor.py
+++ b/transformer_engine/pytorch/tensor/float8_tensor.py
@@ -282,6 +282,14 @@ class Float8CurrentScalingQuantizer(Quantizer):
         if not src.is_contiguous():
             src = src.contiguous()
 
+        # Apply the amax reduction group carried on the destination tensor (e.g. set
+        # by FSDP2) so the in-place re-quantization reduces amax across the mesh. The
+        # group rides on the tensor rather than being stored on the quantizer.
+        group = getattr(dst, "amax_reduction_group", None)
+        if group is not None:
+            self.amax_reduction_group = group
+            self.with_amax_reduction = True
+
         # Launch cast kernel
         tex.quantize(src, self, dst, noop_flag)
 
@@ -787,10 +795,9 @@ class Float8Tensor(Float8TensorStorage, QuantizedTensor):
         if isinstance(self._quantizer, Float8CurrentScalingQuantizer) and mesh is not None:
             # When sharded weight is updated after reduce scattering the gradients in FSDP2,
             # we need to do amax reduction across the mesh to make sure all weight shards are
-            # updated with same scale inverse. Setting the state below in the quantizer will make
-            # sure that updated Quantized weight tensor have same scale inverse across all shards.
-            self._quantizer.amax_reduction_group = mesh.get_group()
-            self._quantizer.with_amax_reduction = True
+            # updated with the same scale inverse. The reduction group is stored on the tensor
+            # and applied to the quantizer when the data is re-quantized in ``_set_data``.
+            self.amax_reduction_group = mesh.get_group()
 
         fsdp_state = _get_module_fsdp_state(module)
         param_group = fsdp_state._fsdp_param_group
@@ -995,6 +1002,13 @@ class Float8Tensor(Float8TensorStorage, QuantizedTensor):
         # Quantize to FP8
         assert self._quantizer is not None, "Can't quantize without a quantizer"
         self._quantizer.internal = False
+        # Apply the amax reduction group carried on this tensor (e.g. set by FSDP2 in
+        # fsdp_pre_all_gather) to the quantizer so the re-quantization reduces amax
+        # across the mesh. C++ reads the group from the quantizer state.
+        group = getattr(self, "amax_reduction_group", None)
+        if group is not None and isinstance(self._quantizer, Float8CurrentScalingQuantizer):
+            self._quantizer.amax_reduction_group = group
+            self._quantizer.with_amax_reduction = True
         self.data = self._quantizer.quantize(tensor)
         if self.requires_grad != tensor.requires_grad:
             self.requires_grad_(requires_grad=tensor.requires_grad)

--- a/transformer_engine/pytorch/tensor/nvfp4_tensor.py
+++ b/transformer_engine/pytorch/tensor/nvfp4_tensor.py
@@ -200,6 +200,14 @@ class NVFP4Quantizer(Quantizer):
         if not src.is_contiguous():
             src = src.contiguous()
 
+        # Apply the amax reduction group carried on the destination tensor (e.g. set
+        # by FSDP2) so the in-place re-quantization reduces amax across the mesh. The
+        # group rides on the tensor rather than being stored on the quantizer.
+        group = getattr(dst, "amax_reduction_group", None)
+        if group is not None:
+            self.amax_reduction_group = group
+            self.with_amax_reduction = True
+
         # Launch cast kernel
         tex.quantize(src, self, dst, noop_flag)
 

--- a/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/float8_tensor_storage.py
@@ -75,6 +75,11 @@ class Float8TensorStorage(QuantizedTensorStorage):
     _transpose: Optional[torch.Tensor]
     _transpose_invalid: bool
 
+    # Amax reduction process group carried on the tensor (e.g. set by FSDP2 in
+    # fsdp_pre_all_gather) and applied to the quantizer when the data is
+    # re-quantized in-place. ``None`` means no amax reduction.
+    amax_reduction_group: Optional[Any]
+
     def __new__(
         cls,
         *args,
@@ -84,6 +89,7 @@ class Float8TensorStorage(QuantizedTensorStorage):
         fake_dtype: Optional[torch.dtype] = None,
         data_transpose: Optional[torch.Tensor] = None,
         quantizer: Optional[Quantizer] = None,
+        amax_reduction_group: Optional[Any] = None,
         **kwargs,
     ):
         if cls is Float8TensorStorage:
@@ -97,6 +103,7 @@ class Float8TensorStorage(QuantizedTensorStorage):
         instance._scale_inv = fp8_scale_inv
         instance._transpose = data_transpose
         instance._transpose_invalid = instance._transpose is None
+        instance.amax_reduction_group = amax_reduction_group
 
         return instance
 
@@ -139,6 +146,7 @@ class Float8TensorStorage(QuantizedTensorStorage):
             "data_transpose": self._transpose,
             "quantizer": self._quantizer,
             "fake_dtype": self._dtype,
+            "amax_reduction_group": self.amax_reduction_group,
         }
 
     def prepare_for_saving(self) -> Tuple[list[Optional[torch.Tensor]], QuantizedTensorStorage]:
@@ -206,6 +214,7 @@ class Float8TensorStorage(QuantizedTensorStorage):
             fake_dtype=self._dtype,
             data_transpose=out_transpose,
             quantizer=self._quantizer,
+            amax_reduction_group=self.amax_reduction_group,
         )
 
     def __repr__(self):

--- a/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
+++ b/transformer_engine/pytorch/tensor/storage/nvfp4_tensor_storage.py
@@ -107,6 +107,10 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
     _nvfp4_use_4over6: bool
     # Global E4M3 scale bound used by this NVFP4 tensor
     _nvfp4_e4m3_max: int
+    # Amax reduction process group carried on the tensor (e.g. set by FSDP2 in
+    # fsdp_pre_all_gather) and applied to the quantizer when the data is
+    # re-quantized in-place. ``None`` means no amax reduction.
+    amax_reduction_group: Optional[Any]
 
     def __new__(
         cls,
@@ -124,6 +128,7 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
         row_scaled_nvfp4: bool = False,
         nvfp4_use_4over6: bool = False,
         nvfp4_e4m3_max: int = 448,
+        amax_reduction_group: Optional[Any] = None,
         **kwargs,
     ):
         if cls is NVFP4TensorStorage:
@@ -144,6 +149,7 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
         instance._row_scaled_nvfp4 = row_scaled_nvfp4
         instance._nvfp4_use_4over6 = nvfp4_use_4over6
         instance._nvfp4_e4m3_max = nvfp4_e4m3_max if nvfp4_use_4over6 else 448
+        instance.amax_reduction_group = amax_reduction_group
 
         return instance
 
@@ -202,6 +208,7 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
             "nvfp4_use_4over6": self._nvfp4_use_4over6,
             "nvfp4_e4m3_max": self._nvfp4_e4m3_max,
             "fake_dtype": self._dtype,
+            "amax_reduction_group": self.amax_reduction_group,
         }
 
     def prepare_for_saving(self) -> Tuple[list[Optional[torch.Tensor]], NVFP4TensorStorage]:
@@ -337,6 +344,7 @@ class NVFP4TensorStorage(QuantizedTensorStorage):
             nvfp4_use_4over6=self._nvfp4_use_4over6,
             nvfp4_e4m3_max=self._nvfp4_e4m3_max,
             fake_dtype=self._dtype,
+            amax_reduction_group=self.amax_reduction_group,
         )
 
     def __repr__(self):


### PR DESCRIPTION
…impl

Float8Tensor/NVFP4Tensor carry an optional amax_reduction_group attribute (set e.g. by FSDP2 in fsdp_pre_all_gather). The in-place re-quantization path reads it from the tensor and sets it on the quantizer before the cast, so amax is reduced across the mesh without changing the C++ quantize API.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] I have read and followed the [contributing guidelines](https://github.com/NVIDIA/TransformerEngine/blob/main/CONTRIBUTING.rst)
- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
